### PR TITLE
Add tests for tokenization of numbers and single/double character tokens

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,11 +4,26 @@ use std::io::prelude::*;
 use std::str::Chars;
 use std::io;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
+enum Exactness {
+    Exact,
+    Inexact,
+    Empty // implied inexact
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum Radix {
+    Binary,
+    Octal,
+    Decimal,
+    Empty, // implied decimal
+    Hexadecimal
+}
+
+#[derive(Debug, PartialEq, Eq)]
 enum TokenKind {
     Eof,            // end-of-file
-    Error,          // error token
-    Point,          // .
+    Whitespace,     // space, newline
     Lparen,         // (
     Rparen,         // )
     Squote,         // '
@@ -18,14 +33,9 @@ enum TokenKind {
     Bslash,         // \
     True,           // #t true
     False,          // #f false
+    Sharp,          // #
     Sharpbslash,    // #\ introduces a character constant
     Sharplparen,    // #( introduces a vector constant
-    SharpE,         // #e number notation (exactness)
-    SharpI,         // #i number notation (exactness)
-    SharpB,         // #b number notation (binary)
-    SharpO,         // #o number notation (octal)
-    SharpH,         // #d number notation (decimal)
-    SharpX,         // #x number notation (hexadecimal)
     Else,           // else
     Arrow,          // =>
     Define,         // define
@@ -47,13 +57,12 @@ enum TokenKind {
     Delay,          // delay
     Quasiquote,     // quasiquote
     Variable,
-    Number,
+    Number(Exactness, Radix),
     String,
     Character,
     // [, ], {, }, | are reserved
 }
 
-#[derive(Debug)]
 pub struct Token {
     kind: TokenKind,
     start: usize,
@@ -67,7 +76,8 @@ pub struct Parser {
 pub struct Lexer<'a> {
     code: &'a str,
     code_itr: Chars<'a>,
-    index: usize,
+    curr_char: char,
+    index: usize
 }
 
 impl Lexer<'_> {
@@ -75,30 +85,32 @@ impl Lexer<'_> {
         Lexer {
             code,
             code_itr,
+            curr_char: '0',
             index: 0
         }
     }
 
-    fn step(&mut self) -> Option<char> {
+    fn step(&mut self) -> char {
         // returns the character that follows the current iterator position,
         // advances the iterator/index
-        // return None at end of file, else return char
+        // return '\0' at end of file, else return char
         match self.code_itr.next() {
             Some(c) => {
                 self.index = self.index + 1;
-                Some(c)
+                self.curr_char = c;
+                c
             },
-            None => None
+            None => '\0'
         }
     }
 
-    fn peek(&mut self) -> Option<char> {
+    fn peek(&mut self) -> char {
         // return the character that follows the current iterator position,
         // but doesn't advance the iterator/index
-        // return None at end of file, else return char
+        // return '\0' at end of file, else return char
         match self.code_itr.clone().peekable().peek() {
-            Some(c) => Some(*c),
-            None => None
+            Some(c) => *c,
+            None => '\0'
         }
     }
 
@@ -134,14 +146,435 @@ impl Lexer<'_> {
         Token{kind: identifier, start: start, len: self.index - start}
     }
 
+    fn step_number_exactness(&mut self, radix: Radix) -> Result<Exactness, String> {
+        // at this function call, radix (#b, #d, #o or #x) has been stepped through
+        let r = match radix {
+            Radix::Binary => 2,
+            Radix::Octal => 8,
+            Radix::Decimal | Radix::Empty => 10,
+            Radix::Hexadecimal => 16,
+        };
+
+        let mut c = self.peek();
+
+        if matches!(c, '\0') {
+            return Err(format!("SyntaxError: Unexpected end-of-file following radix-{:?} specifier", r))
+        } else if matches!(c, '#') {
+            _ = self.step();
+            c = self.peek();
+
+            if matches!(c, '\0') {
+                return Err("SyntaxError: Unexpected end-of-file following '#' in number exactness specifier".to_string())
+            } else if matches!(c, 'e') {
+                _ = self.step();
+                return Ok(Exactness::Exact)
+            } else if matches!(c, 'i') {
+                _ = self.step();
+                return Ok(Exactness::Inexact)
+            } else if self.is_delimiter(&c) {
+                return Err(format!("SyntaxError: Unexpected {:?} delimiter character following '#' in number exactness specifier", self.get_delimiter_as_str(&c)))
+            } else {
+                _ = self.step();
+                return Err(format!("SyntaxError: Unexpected {:?} character following '#' in number exactness specifier", c))
+            }
+        } else {
+            match radix {
+                Radix::Binary => {
+                    if matches!(c, '0'..='1' | '+' | '-') {
+                        return Ok(Exactness::Empty);
+                    } else {
+                        _ = self.step();
+                        return Err(format!("SyntaxError: Unexpected {:?} character following radix-2 specifier. Expects exactness specifier or '0' or '1' or +/- sign", c));
+                    }
+                },
+                Radix::Octal => {
+                    if matches!(c, '0'..='7' | '+' | '-') {
+                        return Ok(Exactness::Empty);
+                    } else {
+                        _ = self.step();
+                        return Err(format!("SyntaxError: Unexpected {:?} character following radix-8 specifier. Expects exactness specifier or '0'..='7' or +/- sign", c));
+                    }
+                    },
+                Radix::Hexadecimal => {
+                    if matches!(c, '0'..='9' | 'a'..='f' | 'A'..='F' | '+' | '-') {
+                        return Ok(Exactness::Empty);
+                    } else {
+                        _ = self.step();
+                        return Err(format!("SyntaxError: Unexpected {:?} character following radix-16 specifier. Expects exactness specifier or '0'..='9' or 'a'..='f' (case-insensitive) or +/- sign", c));
+                    }
+                },
+                Radix::Decimal | Radix::Empty => {
+                    if matches!(c, '0'..='9' | '+' | '-' | '.') {
+                        return Ok(Exactness::Empty);
+                    } else {
+                        return Err(format!("SyntaxError: Unexpected {:?} character following radix-16 specifier. Expects exactness specifier or '0'..='9' or '.' or +/- sign", c));
+                    }
+                }
+            }
+        }
+    }
+
+    fn step_number_radix(&mut self) -> Result<Radix, String> {
+        // at this function call, exactness (#e or #i) has been stepped through
+        let mut c = self.peek();
+        
+        if matches!(c, '\0') {
+            return Err("SyntaxError: Unexpected <end-of-file> following number exactness specifier".to_string())
+        } else if matches!(c, '#') {
+            _ = self.step();
+            c = self.peek();
+
+            if matches!(c, '\0') {
+                return Err("SyntaxError: Unexpected end-of-file following '#' in number radix specifier".to_string())
+            } else if matches!(c, 'd') {
+                _ = self.step();
+                return Ok(Radix::Decimal)
+            } else if matches!(c, 'b') {
+                _ = self.step();
+                return Ok(Radix::Binary)
+            } else if matches!(c, 'o') {
+                _ = self.step();
+                return Ok(Radix::Octal)
+            } else if matches!(c, 'x') {
+                _ = self.step();
+                return Ok(Radix::Hexadecimal)
+            } else if self.is_delimiter(&c) {
+                return Err(format!("SyntaxError: Unexpected {:?} delimiter character following '#' in number radix specifier", self.get_delimiter_as_str(&c)))
+            } else {
+                _ = self.step();
+                return Err(format!("SyntaxError: Unexpected character {:?}. Expected number radix specifier following exactness specifier for non-decimal numbers", c))
+            }
+        } else if matches!(c, '0'..='9' | '.' | '+' | '-') {
+            return Ok(Radix::Empty)
+        } else if self.is_delimiter(&c) {
+            _ = self.step();
+            if c.is_whitespace() {
+                return Err("SyntaxError: Unexpected whitespace character following number exactness specifier".to_string());
+            }
+
+            return Err(format!("SyntaxError: Unexpected {:?} delimiter character following number exactness specifier", c))
+        } else {
+            _ = self.step();
+            return Err(format!("SyntaxError: Unexpected character {:?}. Expected number radix specifier following exactness specifier for non-decimal numbers", c))
+        }
+    }
+
+    fn step_number_digits(&mut self, radix: &Radix) {
+        let mut digit = self.peek();
+        // <digit R>+
+        while (matches!(radix, Radix::Binary) & matches!(digit, '0'..='1')) |
+              (matches!(radix, Radix::Octal) & matches!(digit, '0'..='7')) |
+              (matches!(radix, Radix::Decimal | Radix::Empty) &matches!(digit, '0'..='9')) |
+              (matches!(radix, Radix::Hexadecimal) & matches!(digit, '0'..='9' | 'a'..='f' | 'A'..='F'))
+        {
+            _ = self.step();
+            digit = self.peek();
+        }
+    }
+
+    fn step_number_inexact_hash(&mut self) {
+        let mut ch = self.peek();
+        // #*
+        while matches!(ch, '#') {
+            _ = self.step();
+            ch = self.peek();
+        }
+    }
+
+    fn step_decimal_number_fractional(&mut self) -> Option<String> {
+        self.step_number_digits(&Radix::Decimal);
+        self.step_number_inexact_hash();
+        let mut ch = self.peek();
+        // switch to using pattern matching
+        if matches!(ch, 'e' | 's' | 'f' | 'd' | 'l') {
+            _ = self.step();
+            ch = self.peek();
+            if matches!(ch, '+' | '-') {
+                _ = self.step();
+            }
+            ch = self.peek();
+            if matches!(ch, '0'..='9') {
+                self.step_number_digits(&Radix::Decimal);
+            } else {
+                return Some(format!("SyntaxError: Unexpected {:?}. Expected radix-10 digits to follow exponent marker", self.get_delimiter_as_str(&ch)))
+            }
+        }
+        None
+    }
+
+    fn step_decimal_number_suffix(&mut self) -> Option<String> {
+        _ = self.step();
+        let mut c = self.peek();
+        if matches!(c, '+' | '-') {
+            _ = self.step();
+        }
+                                        
+        c = self.peek();
+        if matches!(c, '0'..='9') {
+            self.step_number_digits(&Radix::Decimal);
+            None
+        } else {
+            return Some(format!("SyntaxError: Unexpected {:?}. Expected radix-10 digits to follow exponent marker", self.get_delimiter_as_str(&c)))
+        }
+    }
+
+    fn step_complex_number_operand(&mut self, radix: &Radix) -> Option<String> {
+        if matches!(radix, Radix::Decimal | Radix::Empty) {
+            match self.peek() {
+                '.' => {
+                    _ = self.step();
+                    match self.peek() {
+                        '0'..='9' => {
+                            match self.step_decimal_number_fractional() {
+                                Some(err) => return Some(err),
+                                None => return None
+                            }
+                        },
+                        ch => {
+                            return Some(format!("SyntaxError: Unexpected {:?}. Expected radix-10 digits to follow '.'", self.get_delimiter_as_str(&ch)))
+                        }
+                    }
+                },
+                '0'..='9' => {
+                    self.step_number_digits(&radix);
+                    match self.peek() {
+                        '#' => {
+                            _ = self.step();
+                            self.step_number_inexact_hash();
+                            match self.peek() {
+                                '.' => {
+                                    _ = self.step();
+                                    self.step_number_inexact_hash();
+                                    let mut c = self.peek();
+                                    if matches!(c, 'e' | 's' | 'f' | 'd' | 'l') {
+                                        match self.step_decimal_number_suffix() {
+                                            Some(err) => return Some(err),
+                                            None => return None
+                                        }
+                                    }
+                                    return None
+                                },
+                                'e' | 's' | 'f' | 'd' | 'l' => {
+                                    match self.step_decimal_number_suffix() {
+                                        Some(err) => return Some(err),
+                                        None => return None
+                                    }
+                                }
+                                '/' => {
+                                    _ = self.step();
+                                    let c = self.peek();
+                                    if matches!(c, '0'..='9') {
+                                        self.step_number_digits(&radix);
+                                    } else {
+                                        return Some(format!("SyntaxError: Unexpected {:?}. Expected radix-10 digits to follow '/'", c))
+                                    }
+                                    self.step_number_inexact_hash();
+                                    return None
+                                }
+                                _ => {
+                                    return None
+                                }
+                            }
+                        },
+                        '.' => {
+                            _ = self.step();
+                            self.step_number_digits(&radix);
+                            self.step_number_inexact_hash();
+                            let c = self.peek();
+                            if matches!(c, 'e' | 's' | 'f' | 'd' | 'l') {
+                                match self.step_decimal_number_suffix() {
+                                    Some(err) => return Some(err),
+                                    None => return None
+                                }
+                            }
+                            return None
+                        },
+                        'e' | 's' | 'f' | 'd' | 'l' => {
+                            match self.step_decimal_number_suffix() {
+                                Some(err) => return Some(err),
+                                None => return None
+                            }
+                        },
+                        '/' => {
+                            _ = self.step();
+                            let c = self.peek();
+                            if matches!(c, '0'..='9') {
+                                self.step_number_digits(&radix);
+                            } else {
+                                return Some(format!("SyntaxError: Unexpected {:?}. Expected radix-10 digits to follow '/'", c))
+                            }
+                            self.step_number_inexact_hash();
+                            return None
+                        }
+                        _ => {
+                            return None
+                        }
+                    }
+                },
+                c => {
+                    return Some(format!("Unexpected {:?}. Expected only valid radix-10 digits", c))
+                }
+            }
+        } else {
+            let base = match radix {
+                Radix::Binary => 2,
+                Radix::Octal => 8,
+                Radix::Hexadecimal => 16,
+                Radix::Decimal | Radix::Empty => unreachable!()
+            };
+
+            let mut c = self.peek();
+            if (matches!(radix, Radix::Binary) & !matches!(c, '0' | '1')) |
+                (matches!(radix, Radix::Octal) & !matches!(c, '0'..='7')) | 
+                (matches!(radix, Radix::Hexadecimal) & !matches!(c, '0'..='9' | 'a'..='f' | 'A'..='F'))
+            {
+                return Some(format!("Unexpected {:?}. Expected only valid radix-{:?} digits", c, base))
+            }
+
+            self.step_number_digits(&radix);
+            self.step_number_inexact_hash();
+
+            match self.peek() {
+                '/' => {
+                    _ = self.step();
+                    c = self.peek();
+                    if (matches!(radix, Radix::Binary) & !matches!(c, '0' | '1')) |
+                        (matches!(radix, Radix::Octal) & !matches!(c, '0'..='7')) | 
+                        (matches!(radix, Radix::Hexadecimal) & !matches!(c, '0'..='9' | 'a'..='f' | 'A'..='F'))
+                    {
+                        return Some(format!("Unexpected {:?}. Expected radix-{:?} digits to follow '/'", c, base))
+                    }
+
+                    self.step_number_digits(&radix);
+                    self.step_number_inexact_hash();
+                    return None
+                }
+                _ => {
+                    return None
+                }
+            }
+        }
+    }
+
+    fn step_number(&mut self, stepped_sign: bool, radix: &Radix) -> Option<String> {
+        let mut c = self.peek();
+        if !stepped_sign {
+            if matches!(c, '+' | '-') {
+                _ = self.step();
+            } else if self.is_delimiter(&c) {
+                return Some(format!("SyntaxError: Unexpected {:?} following prefix within supposed number token", self.get_delimiter_as_str(&c)))
+
+            } else if matches!(c, '\0') {
+                return Some("SyntaxError: Unexpected <end-of-file>".to_string())
+            }
+        }
+
+        c = self.peek();
+        if matches!(c, 'i') {
+            _ = self.step();
+            c = self.peek();
+            
+            if !self.is_delimiter(&c) & !matches!(c, '\0') {
+                return Some(format!("SyntaxError: Unexpected {:?}. Expected delimiter to terminate number token", c))
+            }
+            return None
+        } else if self.is_delimiter(&c) {
+            return Some(format!("SyntaxError: Unexpected {:?} within supposed number token", self.get_delimiter_as_str(&c)))
+        } else if matches!(c, '\0') {
+           return Some("SyntaxError: Unexpected <end-of-file>".to_string()) 
+        }
+
+        match self.step_complex_number_operand(&radix) {
+            Some(err) => return Some(err),
+            None => {
+                c = self.peek();
+            }
+        }
+
+        if matches!(c, '+' | '-') {
+            _ = self.step();
+            c = self.peek();
+            
+            if matches!(c, 'i') {
+                _ = self.step();
+                if !self.is_delimiter(&c) & !matches!(c, '\0') {
+                    return Some(format!("SyntaxError: Unexpected {:?}. Expected delimiter to terminate number token", c))
+                }
+                return None
+            }
+            
+            
+            match self.step_complex_number_operand(&radix) {
+                Some(err) => return Some(err),
+                None => {
+                    c = self.peek();
+                    if matches!(c, 'i') {
+                        _ = self.step();
+                    
+                        if !self.is_delimiter(&c) & !matches!(c, '\0') {
+                            return Some(format!("SyntaxError: Unexpected {:?}. Expected delimiter to terminate number token", c))
+                        }
+                        return None
+                    } else {
+                        return Some(format!("SyntaxError: Unexpected {:?}. Expected 'i' to follow complex number lhs" , c))
+                    }
+                }
+            }
+        } else if matches!(c, '@') {
+            _ = self.step();
+
+            if matches!(c, '+' | '-') {
+                _ = self.step();
+            } else if self.is_delimiter(&c) {
+                return Some(format!("SyntaxError: Unexpected {:?} following prefix within supposed number token", self.get_delimiter_as_str(&c)))
+
+            } else if matches!(c, '\0') {
+                return Some("SyntaxError: Unexpected <end-of-file>".to_string())
+            }
+
+            match self.step_complex_number_operand(&radix) {
+                Some(err) => return Some(err),
+                None => {
+                    c = self.peek();
+                }
+            }
+
+            if !self.is_delimiter(&c) & !matches!(c, '\0') {
+                return Some(format!("SyntaxError: Unexpected {:?}. Expected delimiter to terminate number token", c))
+            }
+            return None
+        } else if matches!(c, 'i') {
+            _ = self.step();
+                    
+            if !self.is_delimiter(&c) & !matches!(c, '\0') {
+                return Some(format!("SyntaxError: Unexpected {:?}. Expected delimiter to terminate number token", c))
+            }
+            return None
+        } else if !self.is_delimiter(&c) & matches!(c, '\0') {
+            return Some(format!("SyntaxError: Unexpected {:?}. Expected delimiter to terminate number token", c))
+        }
+
+        None        
+    }
+    
     fn is_subsequent(&self, c: &char) -> bool {
-        matches!(c, 'A'..='Z' | 'a'..='z' | '!' | '$' | '%' | '*' | '/' | ':' | '<' | '=' | '>' | '^' | '_' | '~' | '0'..='9' | '+' | '-' | '.' | '@')
+        matches!(c, 'A'..='Z' | 'a'..='z' | '!' | '$' | '%' | '*' | '/' | ':' | '<' | '=' | '>' | '?' | '^' | '_' | '~' | '0'..='9' | '+' | '-' | '.' | '@')
     }
 
     fn is_delimiter(&self, c: &char) -> bool {
-        c.is_whitespace() | matches!(c, '(' | ')' | '"' | ';')
+        matches!(c, '(' | ')' | '"' | ';' | ' ' | '\n' | '\0' | '\r')
     }
 
+    fn get_delimiter_as_str(&self, c: &char) -> String {
+        match c {
+            ' ' => "<space>".to_string(),
+            '\n' => "<newline>".to_string(),
+            '\0' => "<end-of-file>".to_string(),
+            _ => c.to_string()
+        }
+    }
+
+    // make it case insensitive
     fn next_token(&mut self) -> Result<Token, String> {
         // return error message if an error, token if valid token
 
@@ -152,112 +585,187 @@ impl Lexer<'_> {
         */
         
         let start = self.index;
-        let c = match self.step() {
-            Some(c) => c,
-            None => return Ok(Token{kind: TokenKind::Eof, start, len: 0})
-        };
+        let mut c = self.peek();
+
+        if c.is_whitespace() {
+            _ = self.step();
+            c = self.peek();
+            while c.is_whitespace() {
+                _ = self.step();
+                c = self.peek();
+            }
+        }
 
         match c {
-            '.' => Ok(Token{kind: TokenKind::Point, start, len: 1}),
+            c if matches!(c, '+' | '-') => {
+                _ = self.step();
+                match self.peek() {
+                    '0'..'9' => {
+                        self.step_number(true, &Radix::Empty);
+                        Ok(Token{kind: TokenKind::Number(Exactness::Empty, Radix::Empty), start, len: self.index - start})
+                    },
+                    'i' => {
+                        self.step_number(true, &Radix::Empty);
+                        Ok(Token{kind: TokenKind::Number(Exactness::Empty, Radix::Empty), start, len: self.index - start})
+                    },
+                    _ => Ok(Token{kind: TokenKind::Variable, start, len: 1})
+                }
+            }
+            c if matches!(c, '/' | '*') => Ok(Token{kind: TokenKind::Variable, start, len: 1}),
+            '.' => {
+                _ = self.step();
+                match self.peek() {
+                    '0'..='9' => {
+                        self.step_decimal_number_fractional();
+                        return Ok(Token{kind: TokenKind::Number(Exactness::Empty, Radix::Empty), start, len: self.index - start})
+                    }
+                    _ => Err("SyntaxError: Expected decimal number token to follow '.' character".to_string())
+                }
+            },
+            '\0' => Ok(Token{kind: TokenKind::Eof, start, len: 1}),
             '(' => Ok(Token{kind: TokenKind::Lparen, start, len: 1}),
             ')' => Ok(Token{kind: TokenKind::Rparen, start, len: 1}),
             '\'' => Ok(Token{kind: TokenKind::Squote, start, len: 1}),
             '`' => Ok(Token{kind: TokenKind::Bquote, start, len: 1}),
             ',' => {
-                match self.peek() {
-                    Some('@') => {
-                        _ = self.step();
-                        Ok(Token{kind: TokenKind::Seqcomma, start, len: 2})
-                    },
-                    _ => Ok(Token{kind: TokenKind::Comma, start, len: 1})
+                _ = self.step();
+                let c = self.peek();
+
+                if matches!(c, '@') {
+                    _ = self.step();
+                    Ok(Token{kind: TokenKind::Seqcomma, start, len: 2})
+                } else if matches!(c, '\0') {
+                    Ok(Token{kind: TokenKind::Comma, start, len: 1})
+                } else {
+                    Err("SyntaxError: ',' is not a valid token".to_string())
                 }
             },
             '#' => {
+                _ = self.step();
                 match self.peek() {
-                    Some('t') => {
+                    't' | 'T' => {
                         _ = self.step();
                         Ok(Token{kind: TokenKind::True, start, len: 2})
                     },
-                    Some('f') => {
+                    'f' | 'F' => {
                         _ = self.step();
                         Ok(Token{kind: TokenKind::False, start, len: 2})
                     },
-                    Some('\\') => {
+                    '\\' => {
                         _ = self.step();
-                        match self.step() {
-                            Some(_a) => Ok(Token{kind: TokenKind::Character, start: start + 2, len: 1}),
-                            None => Err("Expected a character to follow '#\\'".to_string())
+                        match self.peek() {
+                            '\0' => Err("SyntaxError: Unexpected end-of-file character. Expected a character to follow '#\\'".to_string()),
+                            _ => Ok(Token{kind: TokenKind::Character, start: start + 2, len: 1})
                         }
                     },
-                    Some('(') => {
+                    '(' => {
                         _ = self.step();
                         Ok(Token{kind: TokenKind::Sharplparen, start, len: 2})
                     },
-                    Some('e') => {
+                    'e' | 'E' => {
                         _ = self.step();
-                        Ok(Token{kind: TokenKind::SharpE, start, len: 2})
+                        let radix = match self.step_number_radix() {
+                            Ok(r) => r,
+                            Err(err) => return Err(err)
+                        };
+
+                        match self.step_number(false, &radix) {
+                            Some(err) => return Err(err),
+                            None => {
+                                return Ok(Token{kind: TokenKind::Number(Exactness::Exact, radix), start, len: self.index - start});
+                            }
+                        }
                     },
-                    Some('i') => {
+                    'i' | 'I' => {
                         _ = self.step();
-                        Ok(Token{kind: TokenKind::SharpI, start, len: 2})
+                        let radix = match self.step_number_radix() {
+                            Ok(r) => r,
+                            Err(err) => return Err(err)
+                        };
+
+                        self.step_number(false, &radix);
+                        return Ok(Token{kind: TokenKind::Number(Exactness::Inexact, radix), start, len: self.index - start});
                     },
-                    Some('b') => {
+                    'b'| 'B' => {
                         _ = self.step();
-                        Ok(Token{kind: TokenKind::SharpB, start, len: 2})
+                        let exactness = match self.step_number_exactness(Radix::Binary) {
+                            Ok(exactness) => exactness,
+                            Err(err) => return Err(err)
+                        };
+                        self.step_number(false, &Radix::Binary);
+                        return Ok(Token{kind: TokenKind::Number(exactness, Radix::Binary), start, len: self.index - start});
                     },
-                    Some('o') => {
+                    'o' | 'O' => {
                         _ = self.step();
-                        Ok(Token{kind: TokenKind::SharpO, start, len: 2})
+                        let exactness = match self.step_number_exactness(Radix::Octal) {
+                            Ok(exactness) => exactness,
+                            Err(err) => return Err(err)
+                        };
+                        self.step_number(false, &Radix::Octal);
+                        return Ok(Token{kind: TokenKind::Number(exactness, Radix::Octal), start, len: self.index - start});
                     },
-                    Some('h') => {
+                    'x' | 'X' => {
                         _ = self.step();
-                        Ok(Token{kind: TokenKind::SharpH, start, len: 2})
+                        let exactness = match self.step_number_exactness(Radix::Hexadecimal) {
+                            Ok(exactness) => exactness,
+                            Err(err) => return Err(err)
+                        };
+                        self.step_number(false, &Radix::Hexadecimal);
+                        return Ok(Token{kind: TokenKind::Number(exactness, Radix::Hexadecimal), start, len: self.index - start});
                     },
-                    Some('x') => {
+                    'd' | 'D' => {
                         _ = self.step();
-                        Ok(Token{kind: TokenKind::SharpX, start, len: 2})
+                        let exactness = match self.step_number_exactness(Radix::Decimal) {
+                            Ok(exactness) => exactness,
+                            Err(err) => return Err(err)
+                        };
+                        self.step_number(false, &Radix::Decimal);
+                        return Ok(Token{kind: TokenKind::Number(exactness, Radix::Decimal), start, len: self.index - start});
                     },
-                    _ => {
-                        let char_as_str = &self.code[start..start];
-                        Err(format!("Unexpected '{:?}' following a '#'", char_as_str))
+                    c => {
+                        _ = self.step();
+                        if self.is_delimiter(&c) {
+                            return Err("SyntaxError: '#' is not a valid token".to_string())
+                        } else if matches!(c, '\0') {
+                            return Err("SyntaxError: Unexpected <end-of-file> following '#'".to_string())
+                        }
+                        
+                        return Err(format!("SyntaxError: Unexpected {:?} following a '#'", c))
                     }
                 }
-            }
-            c if matches!(c, '+' | '-' | '*' | '/') => {
-                Ok(Token{kind: TokenKind::Variable, start, len: 1})
+            },
+            '0'..='9' => {
+                self.step_number(false, &Radix::Empty);
+                return Ok(Token{kind: TokenKind::Number(Exactness::Empty, Radix::Empty), start, len: self.index - start});
             },
             c if matches!(c, 'A'..='Z' | 'a'..='z' | '!' | '$' | '%' | '*' | '/' | ':' | '<' | '=' | '>' | '^' | '_' | '~' ) => {
                 // Take a peek of the character that follows a letter 
                 // or special initial as described in Section 7.1.1
-                let mut d = match self.peek() {
-                    Some(d) => d,
-                    None => return Ok(self.make_identifier(start))
-                };
+                let mut d = self.peek();
 
-                // While the character is a subsequent and *not* a delimiter, 
+                // While the character is a subsequent, 
                 // proceed the iterator by calling step(). See Section 7.1.1 
                 // for the formal description of 'subsequent'
-                while !self.is_delimiter(&d) & self.is_subsequent(&d) {
-                    _ = match self.step() {
-                        Some(d) => d,
-                        None => return Ok(self.make_identifier(start))
-                    };
+                while self.is_subsequent(&d) {
+                    _ = self.step();
 
-                    d = match self.peek() {
-                        Some(d) => d,
-                        None => return Ok(self.make_identifier(start))
-                    }
+                    d = self.peek();
+                }
+
+                // When no more subsequents are found, the lexer
+                // expects a delimiter. If *not* a delimiter, syntax error
+                if !self.is_delimiter(&d) & !matches!(d, '\0'){
+                    return Err(format!("SyntaxError: Expected delimiter to terminate identifier token. Found {:?} instead", self.get_delimiter_as_str(&d)));
                 }
 
                 return Ok(self.make_identifier(start));
             },
-            _ => Err("Not reachable".to_string())
+            _ => Err(format!("SyntaxError: {:?} is not a valid token", c))
             // Suggested PRs
             // TODO: Extracting number tokens for all the different possible 
             // kinds (binary, octal, decimal, hexadecimal) as specified in Section 7.1.1
             // 
             // TODO: Extracting string tokens as specified in Section 7.1.1
-            // TODO: Extracting character tokens as specified in Section 7.1.1
         }
     }
 }
@@ -277,13 +785,12 @@ impl Parser {
 
     pub fn repl(&self) {
         print!("Scheme-rs REPL ('exit' or 'quit' to terminate session)\n");
-        let mut input = String::new();
         loop {
             // Todo: Implement proper sighandling
+            let mut input = String::new();
             print!("scheme-rs> ");
             io::stdout().flush().unwrap();
             io::stdin().read_line(&mut input).expect("Unexpected read_line() failure");
-            print!("{}", input);
             
             let mut input: String = input.trim().to_string();
             if input == "exit" || input == "quit" {
@@ -292,6 +799,7 @@ impl Parser {
             
             let _ast = self.generate_ast(&input);
             input.clear();
+            assert!(input.is_empty());
         }
     }
 
@@ -301,18 +809,17 @@ impl Parser {
         match f {
             Ok(mut file) => {
                 file.read_to_string(&mut input)
-                        .expect(format!("Failed to read input file '{:?}'", &input).as_str());
+                        .expect(format!("Failed to read input file {:?}", &input).as_str());
             },
             Err(error) => {
-                panic!("Failed to open input file '{:?}' with {:?}", &input, error);
+                panic!("Failed to open input file {:?} with {:?}", &input, error);
             }
         }
     }
 
     pub fn generate_ast(&self, code: &str) -> () {
         let mut lexer = Lexer::new(code, code.chars());
-        let current_token = lexer.next_token().unwrap();
-        print!("{:?}", current_token)
+        let _current_token = lexer.next_token().unwrap();
         /*loop {
             let current_token = match lexer.next_token() {
                 Some(token) => token,

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,7 @@ enum TokenKind {
     Variable,
     Number,
     String,
+    Character,
     // [, ], {, }, | are reserved
 }
 
@@ -183,7 +184,10 @@ impl Lexer<'_> {
                     },
                     Some('\\') => {
                         _ = self.step();
-                        Ok(Token{kind: TokenKind::Sharpbslash, start, len: 2})
+                        match self.step() {
+                            Some(_a) => Ok(Token{kind: TokenKind::Character, start: start + 2, len: 1}),
+                            None => Err("Expected a character to follow '#\\'".to_string())
+                        }
                     },
                     Some('(') => {
                         _ = self.step();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -43,6 +43,10 @@ mod lexer_tests {
         hash_map.insert("(", TokenKind::Lparen);
         hash_map.insert(")", TokenKind::Rparen);
         hash_map.insert("#(", TokenKind::Sharplparen);
+        hash_map.insert("#\\a", TokenKind::Character);
+        hash_map.insert("#\\#", TokenKind::Character);
+        hash_map.insert("#t", TokenKind::True);
+        hash_map.insert("#f", TokenKind::False);
         hash_map.insert("'", TokenKind::Squote);
         hash_map.insert("`", TokenKind::Bquote);
         hash_map.insert(",", TokenKind::Comma);


### PR DESCRIPTION
- Changed the API for interacting with the Rust next() and peekable() functions
- Added tokenization of number and character tokens alongside pretty extensive test coverage