### PR TITLE
Finish implementation of parse tree generation

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -56,7 +56,7 @@ impl Compiler {
 
             let lexer = Lexer::new(&input, input.chars());
             let mut parser = Parser::new(lexer);
-            let _parse_tree = parser.generate_parse_tree();
+            let _program_tree = parser.generate_parse_tree();
             if parser.error_log.len() > 0 {
                 for error in &parser.error_log {
                     println!("{}", error);

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -583,8 +583,7 @@ impl Lexer<'_> {
             _ => c.to_string()
         }
     }
-
-    // make it case insensitive
+    
     pub fn next_token(&mut self) -> Result<Token, String> {
         // return error message if an error, token if valid token
 
@@ -626,7 +625,10 @@ impl Lexer<'_> {
                     }
                 }
             }
-            c if matches!(c, '/' | '*') => Ok(Token{kind: TokenKind::Variable, start, end: self.index + 1}),
+            c if matches!(c, '/' | '*') => {
+                _ = self.step();
+                Ok(Token{kind: TokenKind::Variable, start, end: self.index})
+            },
             '.' => {
                 _ = self.step();
                 match self.peek() {

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -68,6 +68,7 @@ pub enum TokenKind {
     // [, ], {, }, | are reserved
 }
 
+#[derive(Clone, Copy)]
 pub struct Token {
     pub kind: TokenKind,
     pub start: usize,
@@ -621,7 +622,6 @@ impl Lexer<'_> {
                         Ok(Token{kind: TokenKind::Number, start, end: self.index})
                     },
                     _ => {
-                        _ = self.step();
                         Ok(Token{kind: TokenKind::Variable, start, end: self.index})
                     }
                 }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -61,6 +61,7 @@ pub enum TokenKind {
     Do,             // do
     Delay,          // delay
     Quasiquote,     // quasiquote
+    DefineSyntax,   // define-syntax
     Variable,
     Number,
     String,
@@ -146,6 +147,7 @@ impl Lexer<'_> {
             "do" => TokenKind::Do,
             "delay" => TokenKind::Delay,
             "quasiquote" => TokenKind::Quasiquote,
+            "define-syntax" => TokenKind::DefineSyntax,
             _ => TokenKind::Variable
         }
     }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -614,12 +614,10 @@ impl Lexer<'_> {
                 match self.peek() {
                     '0'..'9' => {
                         self.step_number(true, &Radix::Empty);
-                        _ = self.step();
                         Ok(Token{kind: TokenKind::Number, start, end: self.index})
                     },
                     'i' => {
                         self.step_number(true, &Radix::Empty);
-                        _ = self.step();
                         Ok(Token{kind: TokenKind::Number, start, end: self.index})
                     },
                     _ => {
@@ -636,7 +634,6 @@ impl Lexer<'_> {
                 match self.peek() {
                     '0'..='9' => {
                         self.step_decimal_number_fractional();
-                        _ = self.step();
                         Ok(Token{kind: TokenKind::Number, start, end: self.index})
                     }
                     _ => {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -38,10 +38,17 @@ enum TreeKind {
     Number,
     Character,
     String,
+    Literal,
+    Quotation,
+    SelfEvaluating,
     Datum,
+    SimpleDatum,
+    CompoundDatum,
     List,
     Vector,
     Abbreviation,
+    AbbrevPrefix,
+    Symbol,
     Variable,
     Keyword,
     ProcedureCall,
@@ -81,20 +88,20 @@ pub struct Tree {
 }
 
 impl Tree {
-    fn open(kind: TreeKind, start: usize, children: Option<Vec<Tree>>) -> Tree {
+    fn open(kind: TreeKind, start: usize) -> Tree {
         Tree {
             kind,
             start,
             end: start,
-            children
+            children: Some(Vec::new())
         }
     }
 
-    fn leaf(kind: TreeKind, start: usize, end: usize) -> Tree {
+    fn leaf(kind: TreeKind, token_at_leaf: &Token) -> Tree {
         Tree {
             kind,
-            start,
-            end,
+            start: token_at_leaf.start,
+            end: token_at_leaf.end,
             children: None
         }
     }
@@ -114,6 +121,8 @@ impl Tree {
         assert_ne!(self.kind, TreeKind::String);
         assert_ne!(self.kind, TreeKind::Boolean);
         assert_ne!(self.kind, TreeKind::Variable);
+        assert_ne!(self.kind, TreeKind::Keyword);
+        assert_ne!(self.kind, TreeKind::Error);
 
         match self.children {
             Some(ref mut vec) => {
@@ -132,18 +141,30 @@ impl Tree {
 
     fn print(&self, level: usize, lexer: &Lexer<'_>) {
         let indent = "  ".repeat(level);
-        println!("{indent}{:?}", self.kind);
         let children = &self.children;
-        
+
         match children {
             Some(vec) => {
+                println!("{indent}{:?}", self.kind);
+
                 for child in vec{
                     child.print(level + 1, lexer);
                 }
             },
             None => {
                 let literal = &lexer.code[self.start..self.end];
-                println!("  {indent}{:?}", literal);
+                
+                if matches!(self.kind, TreeKind::Keyword | TreeKind::Variable | TreeKind::Boolean | TreeKind::Number | TreeKind::Character | TreeKind::String) {
+                    println!("{indent}{:?}", self.kind);
+                    println!("  {indent}{:?}", literal);
+                    return
+                } else if matches!(self.kind, TreeKind::Error) {
+                    println!("{indent}{:?}", self.kind);
+                    return
+                }
+                
+                let literal = &lexer.code[self.start..self.end];
+                println!("{indent}{:?}", literal);
             }
         }
     }
@@ -152,6 +173,7 @@ impl Tree {
 pub struct Parser<'a> {
     lexer: Lexer<'a>,
     curr_token: Token,
+    after_curr: Token,
     pub error_log: Vec<String>,
 }
 
@@ -160,13 +182,14 @@ impl Parser<'_>{
         Parser {
             lexer: lexer,
             curr_token: Token{kind: TokenKind::Eof, start: 0, end: 1},
+            after_curr: Token{kind: TokenKind::Eof, start: 0, end: 1},
             error_log: Vec::new()
         }
     }
 
     // skip tokens until parser reaches non-whitespace delimiter token
     fn synchronize_from_parse_error(&mut self) {
-        while matches!(self.curr_token.kind, TokenKind::Lparen | TokenKind::Rparen | TokenKind::String | TokenKind::Semicolon) {
+        while !matches!(self.curr_token.kind, TokenKind::Lparen | TokenKind::Rparen | TokenKind::String | TokenKind::Semicolon | TokenKind::Eof) {
             self.advance();
         }
     }
@@ -203,19 +226,49 @@ impl Parser<'_>{
         self.curr_token.kind == kind
     }
 
-    fn expect(&mut self, kind: TokenKind) {
+    // checks that the token that follows curr_token is of kind, but doesn't update curr_token in the parser
+    fn after(&mut self, kind: TokenKind) -> bool {
+        self.after_curr = match self.lexer.next_token() {
+            Ok(token) => token,
+            Err(error) => {
+                self.error_log.push(error);
+                let mut res = self.lexer.next_token();
+
+                while res.is_err() {
+                    self.error_log.push(res.err().unwrap());
+                    res = self.lexer.next_token();
+                }
+                res.ok().unwrap()
+            }
+        };
+
+        self.after_curr.kind == kind 
+    }
+
+    fn at_any(&self, kinds: &[TokenKind]) -> bool {
+        for kind in kinds {
+            if self.at(*kind) {
+                return true
+            }
+        }
+        false
+    }
+
+    fn expect(&mut self, curr_tree: &mut Tree, kind: TokenKind) {
         if self.at(kind) {
-            self.advance();
+            curr_tree.add_child(Tree::leaf(TreeKind::Token, &self.curr_token));
+            return
         }
 
+        curr_tree.add_child(Tree::leaf(TreeKind::Error, &self.curr_token));
         self.add_error_msg_to_log(format!("Expected a {:?}", kind).as_str());
         self.synchronize_from_parse_error();
     }
 
-    fn is_at_keyword(&self) -> bool {
+    fn at_keyword(&self) -> bool {
         matches!(self.curr_token.kind, TokenKind::Else | TokenKind::Arrow | TokenKind::Define
         | TokenKind::Unquote | TokenKind::UnquoteSplicing | TokenKind::Quote
-        | TokenKind::Lambda | TokenKind::SetExPt | TokenKind::Begin
+        | TokenKind::Lambda | TokenKind::If | TokenKind::SetExPt | TokenKind::Begin
         | TokenKind::Cond | TokenKind::And | TokenKind::Or
         | TokenKind::Case | TokenKind::Let | TokenKind::LetStar
         | TokenKind::LetRec | TokenKind::Do | TokenKind::Delay
@@ -223,113 +276,165 @@ impl Parser<'_>{
     }
 
     fn list(&mut self) -> Tree {
-        let mut list = Tree::open(TreeKind::List, self.curr_token.start, Some(Vec::new()));
-        // '('
-        let child = Tree::leaf(TreeKind::Token, self.curr_token.start, self.curr_token.end);
-        list.add_child(child);
+        let mut list = Tree::open(TreeKind::List, self.curr_token.start);
 
-        self.advance();
-        while !self.at(TokenKind::Rparen) {
-            list.add_child(self.datum());
+        if self.at(TokenKind::Lparen) {
+            list.add_child(Tree::leaf(TreeKind::Token, &self.curr_token));
             self.advance();
-        }
+            while !self.at_any(&[TokenKind::Rparen, TokenKind::Eof, TokenKind::Dot]) {
+                list.add_child(self.datum());
+                self.advance();
+            }
 
-        if list.children_count() > 2 && self.at(TokenKind::Dot) {
+            if list.children_count() > 2 && self.at(TokenKind::Dot) {
+                list.add_child(Tree::leaf(TreeKind::Token, &self.curr_token));
+                self.advance();
+                list.add_child(self.datum());
+                self.advance();
+            }
+            self.expect(&mut list, TokenKind::Rparen);
+        } else if self.at_any(&[TokenKind::Squote, TokenKind::Bquote, TokenKind::Comma, TokenKind::Seqcomma]) {
+            let mut abbreviation = Tree::open(TreeKind::Abbreviation, self.curr_token.start);
+            let mut abbrev_prefix = Tree::open(TreeKind::AbbrevPrefix, self.curr_token.start);
+            abbrev_prefix.add_child(Tree::leaf(TreeKind::Token, &self.curr_token));
+            abbrev_prefix.close(self.lexer.index);
+            abbreviation.add_child(abbrev_prefix);
             self.advance();
-            list.add_child(self.datum());
+            abbreviation.add_child(self.datum());
+            abbreviation.close(self.lexer.index);
+            list.add_child(abbreviation);
         }
         
         list.close(self.lexer.index);
         list
     }
 
-    fn abbreviation(&mut self) -> Tree {
-        let mut abbreviation = Tree::open(TreeKind::Abbreviation, self.curr_token.start, Some(Vec::new()));
-        // abbreviation prefix
-        let child = Tree::leaf(TreeKind::Token, self.curr_token.start, self.curr_token.end);
-        abbreviation.add_child(child);
-        
+    fn vector(&mut self) -> Tree {
+        let mut vector = Tree::open(TreeKind::Vector, self.curr_token.start);
+        vector.add_child(Tree::leaf(TreeKind::Token, &self.curr_token));
         self.advance();
-        abbreviation.add_child(self.datum());
-
-        abbreviation.close(self.lexer.index);
-        abbreviation
+        while !self.at_any(&[TokenKind::Rparen, TokenKind::Eof]) {
+            vector.add_child(self.datum());
+            self.advance();
+        }
+        self.expect(&mut vector, TokenKind::Rparen);
+        vector.close(self.lexer.index);
+        vector
     }
 
     fn datum(&mut self) -> Tree {
-        self.advance();
-        let mut datum = Tree::open(TreeKind::Datum, self.curr_token.start, Some(Vec::new()));
-        if self.at(TokenKind::True) || self.at(TokenKind::False) {
-            let child = Tree::leaf(TreeKind::Boolean, self.curr_token.start, self.curr_token.end);
-            datum.add_child(child);
-        } else if self.at(TokenKind::String) {
-            let child = Tree::leaf(TreeKind::String, self.curr_token.start, self.curr_token.end);
-            datum.add_child(child);
-        } else if self.at(TokenKind::Number) {
-            let child = Tree::leaf(TreeKind::Number, self.curr_token.start, self.curr_token.end);
-            datum.add_child(child);
-        } else if self.at(TokenKind::Character) {
-            let child = Tree::leaf(TreeKind::Character, self.curr_token.start, self.curr_token.end);
-            datum.add_child(child);
-        } else if self.at(TokenKind::Variable) {
-            let child = Tree::leaf(TreeKind::Variable, self.curr_token.start, self.curr_token.end);
-            datum.add_child(child);
-        } else if self.at(TokenKind::Lparen) {
-            self.advance();
-            datum.add_child(self.list());
-            self.expect(TokenKind::Rparen);
-        }
-        else if self.at(TokenKind::Squote) || self.at(TokenKind::Bquote) || self.at(TokenKind::Comma) || self.at(TokenKind::Seqcomma) {
-            self.advance();
-            datum.add_child(self.abbreviation());
+        let mut datum = Tree::open(TreeKind::Datum, self.curr_token.start);
+        if self.at(TokenKind::Lparen) | self.at_any(&[TokenKind::Squote, TokenKind::Bquote, TokenKind::Comma, TokenKind::Seqcomma]){
+            // List
+            let mut compound_datum = Tree::open(TreeKind::CompoundDatum, self.curr_token.start);
+            compound_datum.add_child(self.list());
+            compound_datum.close(self.lexer.index);
+            datum.add_child(compound_datum);
         } else if self.at(TokenKind::Sharplparen) {
-            // TODO: VECTOR
-        } else if self.is_at_keyword() {
-            let child = Tree::leaf(TreeKind::Keyword, self.curr_token.start, self.curr_token.end);
-            datum.add_child(child);
+            // Vectors
+            let mut compound_datum = Tree::open(TreeKind::CompoundDatum, self.curr_token.start);
+            compound_datum.add_child(self.vector());
+            compound_datum.close(self.lexer.index);
+            datum.add_child(compound_datum);
         } else {
-            self.add_error_msg_to_log( "Expected a datum");
-            self.synchronize_from_parse_error();
+            let mut simple_datum = Tree::open(TreeKind::SimpleDatum, self.curr_token.start);
+
+            if self.at(TokenKind::True) || self.at(TokenKind::False) {
+                simple_datum.add_child(Tree::leaf(TreeKind::Boolean, &self.curr_token));
+            } else if self.at(TokenKind::String) {
+                simple_datum.add_child(Tree::leaf(TreeKind::String, &self.curr_token));
+            } else if self.at(TokenKind::Number) {
+                simple_datum.add_child(Tree::leaf(TreeKind::Number, &self.curr_token));
+            } else if self.at(TokenKind::Character) {
+                simple_datum.add_child(Tree::leaf(TreeKind::Character, &self.curr_token))
+            } else if self.at(TokenKind::Variable) {
+                let mut symbol = Tree::open(TreeKind::Symbol, self.curr_token.start);
+                symbol.add_child(Tree::leaf(TreeKind::Variable, &self.curr_token));
+                symbol.close(self.lexer.index);
+                simple_datum.add_child(symbol);
+            } else if self.at_keyword() {
+                let mut symbol = Tree::open(TreeKind::Symbol, self.curr_token.start);
+                symbol.add_child(Tree::leaf(TreeKind::Keyword, &self.curr_token));
+                symbol.close(self.lexer.index);
+                simple_datum.add_child(symbol);
+            }
+
+            simple_datum.close(self.lexer.index);
+            datum.add_child(simple_datum);
         }
+
         datum.close(self.lexer.index);
         datum
     }
 
-    fn expression(&mut self) -> Tree {
-        let mut expression = Tree::open(TreeKind::Expression, self.curr_token.start, Some(Vec::new()));
-        if self.at(TokenKind::Variable) {
-            let child = Tree::leaf(TreeKind::Variable, self.curr_token.start, self.curr_token.end);
-            expression.add_child(child);
-        } else if self.at(TokenKind::Squote) {
-            let child = Tree::leaf(TreeKind::Token, self.curr_token.start, self.curr_token.end);
-            expression.add_child(child);
+    fn literal(&mut self) -> Tree {
+        let mut literal = Tree::open(TreeKind::Literal, self.curr_token.start);
+        if self.at(TokenKind::Squote) {
+            let mut quotation = Tree::open(TreeKind::Quotation, self.curr_token.start);
+            quotation.add_child(Tree::leaf(TreeKind::Token, &self.curr_token));
             self.advance();
-            expression.add_child(self.datum());
-        } else if self.at(TokenKind::False) || self.at(TokenKind::True) {
-            let child = Tree::leaf(TreeKind::Boolean, self.curr_token.start, self.curr_token.end);
-            expression.add_child(child);
-        } else if self.at(TokenKind::String) {
-            let child = Tree::leaf(TreeKind::String, self.curr_token.start, self.curr_token.end);
-            expression.add_child(child);
-        } else if self.at(TokenKind::Number) {
-            let child = Tree::leaf(TreeKind::Number, self.curr_token.start, self.curr_token.end);
-            expression.add_child(child);
-        } else if self.at(TokenKind::Character) {
-            let child = Tree::leaf(TreeKind::Character, self.curr_token.start, self.curr_token.end);
-            expression.add_child(child);
+            quotation.add_child(self.datum());
+            quotation.close(self.lexer.index);
+            literal.add_child(quotation);
+        } else if self.at(TokenKind::Lparen) && self.after_curr.kind == TokenKind::Quote {
+            let mut quotation = Tree::open(TreeKind::Quotation, self.curr_token.start);
+            quotation.add_child(Tree::leaf(TreeKind::Token, &self.curr_token));
+            
+            let mut symbol = Tree::open(TreeKind::Symbol, self.after_curr.start);
+            symbol.add_child(Tree::leaf(TreeKind::Keyword, &self.after_curr));
+            symbol.close(self.lexer.index);
+            quotation.add_child(symbol);
+
+            self.advance();
+            quotation.add_child(self.datum());
+            self.advance();
+            self.expect(&mut quotation, TokenKind::Rparen);
+            quotation.close(self.lexer.index);
+            literal.add_child(quotation);
+        } else {
+            let mut selfeval = Tree::open(TreeKind::SelfEvaluating, self.curr_token.start);
+
+            if self.at_any(&[TokenKind::False, TokenKind::True]) {
+                selfeval.add_child(Tree::leaf(TreeKind::Boolean, &self.curr_token));
+            } else if self.at(TokenKind::Number) {
+                selfeval.add_child(Tree::leaf(TreeKind::Number, &self.curr_token));
+            } else if self.at(TokenKind::Character) {
+                selfeval.add_child(Tree::leaf(TreeKind::Character, &self.curr_token));
+            } else if self.at(TokenKind::String) {
+                selfeval.add_child(Tree::leaf(TreeKind::String, &self.curr_token));
+            }
+
+            selfeval.close(self.lexer.index);
+            literal.add_child(selfeval);
+        }
+
+        literal.close(self.lexer.index);
+        literal
+    }
+    
+    fn expression(&mut self) -> Tree {
+        let mut expression = Tree::open(TreeKind::Expression, self.curr_token.start);
+        if self.at(TokenKind::Variable) {
+            expression.add_child(Tree::leaf(TreeKind::Variable, &self.curr_token));
+        } else if self.at_any(&[TokenKind::Squote, TokenKind::True, TokenKind::False, TokenKind::Number, TokenKind::Character, TokenKind::String]) {
+            expression.add_child(self.literal());
+        } else if self.at(TokenKind::Lparen) && self.after(TokenKind::Quote) {
+            expression.add_child(self.literal());
         } else if self.at(TokenKind::Lparen) {
             // TODO
         } else {
+            expression.add_child(Tree::leaf(TreeKind::Error, &self.curr_token));
             self.add_error_msg_to_log("Expected an expression");
             self.synchronize_from_parse_error();
         }
+
         expression.close(self.lexer.index);
         expression
     }
 
     pub fn generate_parse_tree(&mut self) -> Tree {
         let start = self.lexer.index;
-        let mut root = Tree::open(TreeKind::File, start, Some(Vec::new()));
+        let mut root = Tree::open(TreeKind::File, start);
         self.advance();
         loop {
             root.add_child(self.expression());


### PR DESCRIPTION
This pull request completes the base parse tree generation setup already implemented in [this](https://github.com/wldfngrs/scheme-rs/commit/4ae452215115ed4d712dffc694ca0205c6970479) commit. Given a source, the parser returns a parse tree according to the formal syntax described in Section 7.1.2 and Section 7.1.3 of the [Scheme Implementation Paper](https://web.stanford.edu/class/me469b/download/scheme.pdf)

This pull request also fixes some lexing bugs that showed up during the implementation of the parser.