### PR TITLE
Add Primitive IR generation

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -4,6 +4,7 @@ use std::io;
 
 use crate::lexer::Lexer;
 use crate::parser::Parser;
+use crate::ir::{IrCtx, IrArena};
 
 #[derive(Eq, PartialEq)]
 enum ExecutionMode {
@@ -56,12 +57,16 @@ impl Compiler {
 
             let lexer = Lexer::new(&input, input.chars());
             let mut parser = Parser::new(lexer);
-            let _program_tree = parser.generate_parse_tree();
-            if parser.error_log.len() > 0 {
-                for error in &parser.error_log {
-                    println!("{}", error);
-                }
+            let program = parser.generate_parse_tree();
+            if parser.has_errors() {
+                parser.print_errors();
             }
+
+            let mut prim_ir = IrArena::new();
+            let root_id = program.to_prim_ir(&mut prim_ir, &input);
+
+            let ir_ctx = IrCtx::init(&input);
+            
             input.clear();
         }
     }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -4,7 +4,7 @@ use std::io;
 
 use crate::lexer::Lexer;
 use crate::parser::Parser;
-use crate::ir::{IrCtx, IrArena};
+use crate::ir::IrArena;
 
 #[derive(Eq, PartialEq)]
 enum ExecutionMode {
@@ -64,8 +64,6 @@ impl Compiler {
 
             let mut prim_ir = IrArena::new();
             let root_id = program.to_prim_ir(&mut prim_ir, &input);
-
-            let ir_ctx = IrCtx::init(&input);
             
             input.clear();
         }

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -18,7 +18,8 @@ enum NumKind {
 pub type IrID = usize;
 
 pub enum PrimIrKind {
-    Environment(VecDeque<IrID>),
+    //Undefined,
+    Environment(IrID),
     Exprs(VecDeque<IrID>),
     Boolean(bool),
     Symbol(String),
@@ -46,17 +47,21 @@ pub enum PrimIrKind {
     Number(NumKind),
     String(String),
     Define {
-        name: String,
+        name: IrID,
         value: IrID,
     },
     Set {
-        variable: String,
+        variable: IrID,
         expression: IrID
     },
     Conditional {
         test: IrID, 
         consequent: IrID, 
         alternate: Option<IrID>
+    },
+    Loop {
+        inits: Vec<IrID>,
+        body: Vec<IrID>
     }
     //Port
 }
@@ -84,6 +89,9 @@ impl<T> IrArena<T> {
     }
 
     pub fn add(&mut self, kind: T, span: (usize, usize)) -> IrID {
+        // use a hash table for the arena, if an IrNode already exists in the hash table,
+        // it is in the arena, and the stored id should be returned, else add to the hash table,
+        // and arena and return the ids
         let i = self.nodes.len();
         self.nodes.push(IrNode { kind, span });
         i

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -1,0 +1,101 @@
+use std::str::Chars;
+
+use crate::tree::FormalsTy;
+
+enum NumKind {
+    Complex {
+        lhs: f64, 
+        rhs: f64
+    },
+    Real(f64),
+    Rational {
+        num: f64,
+        den: f64
+    },
+    Integer(i64)
+}
+
+pub type IrID = usize;
+
+pub enum PrimIrKind {
+    Exprs(Vec<IrID>),
+    Boolean(bool),
+    Symbol(String),
+    Char(String),
+    Vector(Vec<IrID>),
+    Call {
+        operator: IrID,
+        operands: Vec<IrID>
+    },
+    Lambda {
+        ty: FormalsTy,
+        formals: Vec<IrID>,
+        body: Vec<IrID>
+    },
+    Error,
+    Pair {
+        car: IrID, 
+        cdr: Option<IrID>
+    },
+    Number(NumKind),
+    String(String),
+    Define {
+        name: IrID,
+        value: IrID,
+    },
+    Set {
+        variable: IrID,
+        expression: IrID
+    },
+    Conditional {
+        test: IrID, 
+        consequent: IrID, 
+        alternate: Option<IrID>
+    }
+    //Port
+}
+
+pub struct PrimIr {
+    pub kind: PrimIrKind
+}
+
+/*struct LambdaIr {
+    kind: LambdaIrKind
+}*/
+
+struct IrNode<T> {
+    kind: T,
+    span: (usize, usize)
+}
+
+pub struct IrArena<T> {
+    nodes: Vec<IrNode<T>>
+}
+
+impl<T> IrArena<T> {
+    pub fn new() -> IrArena<T> {
+        IrArena { nodes: Vec::new() }
+    }
+
+    pub fn add(&mut self, kind: T, span: (usize, usize)) -> IrID {
+        let i = self.nodes.len();
+        self.nodes.push(IrNode { kind, span });
+        i
+    }
+}
+
+pub struct IrCtx<'code> {
+    code: &'code str
+}
+
+impl<'code> IrCtx<'code> {
+    pub fn init(code: &'code str) -> IrCtx<'code> {
+        IrCtx { 
+            code: code,
+        }
+    }
+
+    /*pub fn lambda_ir_from<T>(&self, prim_ir: IrArena<PrimIr>, start_id: IrID, lambda_ir: &mut IrArena) -> () {
+
+    }*/
+}

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -96,24 +96,4 @@ impl<T> IrArena<T> {
         self.nodes.push(IrNode { kind, span });
         i
     }
-
-    pub fn node_at(&self, id: IrID) -> &IrNode<T> {
-        return &self.nodes[id];
-    }
-}
-
-pub struct IrCtx<'code> {
-    code: &'code str
-}
-
-impl<'code> IrCtx<'code> {
-    pub fn init(code: &'code str) -> IrCtx<'code> {
-        IrCtx { 
-            code: code,
-        }
-    }
-
-    /*pub fn lambda_ir_from<T>(&self, prim_ir: IrArena<PrimIr>, start_id: IrID, lambda_ir: &mut IrArena) -> () {
-
-    }*/
 }

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -1,4 +1,4 @@
-use std::{collections::VecDeque, str::Chars};
+use std::{collections::{HashMap, VecDeque}};
 
 use crate::tree::FormalsTy;
 
@@ -18,14 +18,20 @@ enum NumKind {
 pub type IrID = usize;
 
 pub enum PrimIrKind {
+    Environment(VecDeque<IrID>),
     Exprs(VecDeque<IrID>),
     Boolean(bool),
     Symbol(String),
     Char(String),
     Vector(Vec<IrID>),
     Call {
-        operator: String,
+        operator: IrID,
         operands: Vec<IrID>
+    },
+    Procedure {
+        //closure: Env,
+        params: Vec<String>,
+        body: Vec<IrID>,
     },
     Lambda {
         ty: FormalsTy,

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -1,4 +1,4 @@
-use std::str::Chars;
+use std::{collections::VecDeque, str::Chars};
 
 use crate::tree::FormalsTy;
 
@@ -18,13 +18,13 @@ enum NumKind {
 pub type IrID = usize;
 
 pub enum PrimIrKind {
-    Exprs(Vec<IrID>),
+    Exprs(VecDeque<IrID>),
     Boolean(bool),
     Symbol(String),
     Char(String),
     Vector(Vec<IrID>),
     Call {
-        operator: IrID,
+        operator: String,
         operands: Vec<IrID>
     },
     Lambda {
@@ -40,11 +40,11 @@ pub enum PrimIrKind {
     Number(NumKind),
     String(String),
     Define {
-        name: IrID,
+        name: String,
         value: IrID,
     },
     Set {
-        variable: IrID,
+        variable: String,
         expression: IrID
     },
     Conditional {
@@ -63,9 +63,9 @@ pub struct PrimIr {
     kind: LambdaIrKind
 }*/
 
-struct IrNode<T> {
-    kind: T,
-    span: (usize, usize)
+pub struct IrNode<T> {
+    pub kind: T,
+    pub span: (usize, usize)
 }
 
 pub struct IrArena<T> {
@@ -81,6 +81,10 @@ impl<T> IrArena<T> {
         let i = self.nodes.len();
         self.nodes.push(IrNode { kind, span });
         i
+    }
+
+    pub fn node_at(&self, id: IrID) -> &IrNode<T> {
+        return &self.nodes[id];
     }
 }
 

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -5,23 +5,6 @@
 // TODO: Change stepped_sign to enum
 
 use std::str::Chars;
-use std::fmt;
-
-#[derive(Debug, PartialEq, Eq)]
-pub enum Exactness {
-    Exact,
-    Inexact,
-    Empty // implied inexact
-}
-
-#[derive(Debug, PartialEq, Eq)]
-pub enum Radix {
-    Binary,
-    Octal,
-    Decimal,
-    Empty, // implied decimal
-    Hexadecimal
-}
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum TokenKind {
@@ -76,15 +59,37 @@ pub struct Token {
     pub end: usize,
 }
 
-pub struct Lexer<'a> {
-    pub code: &'a str,
-    code_itr: Chars<'a>,
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum Exactness {
+    Exact,
+    Inexact,
+    Empty // implied exact
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum Radix {
+    Binary,
+    Octal,
+    Decimal,
+    Empty, // implied decimal
+    Hexadecimal
+}
+
+#[derive(Clone)]
+pub struct NumQEntry {
+    pub exactness: Exactness,
+    pub radix: Radix,
+}
+
+pub struct Lexer<'code> {
+    pub code: &'code str,
+    code_itr: Chars<'code>,
     curr_char: char,
     pub index: usize
 }
 
 impl Lexer<'_> {
-    pub fn new<'a>(code: &'a str, code_itr: Chars<'a>) -> Lexer<'a> {
+    pub fn new<'code>(code: &'code str, code_itr: Chars<'code>) -> Lexer<'code> {
         Lexer {
             code,
             code_itr,
@@ -637,8 +642,6 @@ impl Lexer<'_> {
                         Ok(Token{kind: TokenKind::Number, start, end: self.index})
                     }
                     _ => {
-                        //.synchronize_to_delimiter_after_error();
-                        //Err("SyntaxError: Expected decimal number token to follow '.' character".to_string())
                         _ = self.step();
                         Ok(Token{kind: TokenKind::Dot, start, end: self.index})
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,9 @@
 mod tests;
-mod lexer;
-mod parser;
 mod compiler;
+mod parser;
+mod tree;
+mod lexer;
+mod ir;
 
 use std::env;
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,7 +1,7 @@
 // TODO: Improve error messages with source information for the tree node where the parse error occured
 
 use crate::lexer::{Lexer, Token, TokenKind};
-use crate::tree::{Tree, TreeKind, FormalsTy, ListTy, DefineTy};
+use crate::tree::{Tree, TreeKind, FormalsTy, ListTy, DefineTy, CondTy};
 
 #[derive(PartialEq, Eq)]
 enum BeginTerminalSite {
@@ -535,7 +535,7 @@ impl<'a> Parser<'a>{
     }
 
     fn parse_cond_clause(&mut self) -> Tree {
-        let mut cond_clause = Tree::open(TreeKind::CondClause, self.curr_token.start);
+        let mut cond_clause = Tree::open(TreeKind::CondClause(CondTy::Type1), self.curr_token.start);
 
         // (
         cond_clause.add_child(Tree::leaf(TreeKind::Token, &self.curr_token));
@@ -548,9 +548,11 @@ impl<'a> Parser<'a>{
 
         self.advance();
         if self.at(TokenKind::Rparen) {
+            cond_clause.kind = TreeKind::CondClause(CondTy::Type2);
             cond_clause.add_child(Tree::leaf(TreeKind::Token, &self.curr_token));
         } else if self.at(TokenKind::Arrow) {
             // =>
+            cond_clause.kind = TreeKind::CondClause(CondTy::Type3);
             cond_clause.add_child(Tree::leaf(TreeKind::Token, &self.curr_token));
 
             self.advance();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,86 +1,7 @@
 // TODO: Improve error messages with source information for the tree node where the parse error occured
 
-use crate::lexer::{Lexer, Token, Exactness, Radix, TokenKind};
-
-enum NumberExactness {
-    Exact,
-    Inexact {
-        upper: NumberKind
-    }
-}
-
-enum NumberKind {
-    Number,
-    Complex {
-        lhs: f64, 
-        rhs: f64
-    },
-    Real(f64),
-    Rational {
-        num: f64,
-        den: f64
-    },
-    Integer(i64)
-}
-
-/* Number {
-        kind: NumberKind,
-        radix: Radix,
-        exactness: NumberExactness,
-    },*/
-
-#[derive(PartialEq, Debug)]
-enum TreeKind {
-    Program,
-    CommandOrDefinition,
-    Token,
-    Expression,
-    Boolean,
-    Number,
-    Character,
-    String,
-    Literal,
-    Quotation,
-    SelfEvaluating,
-    Datum,
-    SimpleDatum,
-    CompoundDatum,
-    List,
-    Vector,
-    Abbreviation,
-    AbbrevPrefix,
-    Symbol,
-    Variable,
-    Keyword,
-    ProcedureCall,
-    Operator,
-    Operand,
-    LambdaExpr,
-    Formals,
-    Body,
-    Definition,
-    DefFormals,
-    Sequence,
-    Command,
-    Conditional,
-    Test,
-    Consequent,
-    Alternate,
-    Assignment,
-    DerivedExpr,
-    CondClause,
-    CaseClause,
-    BindingSpec,
-    IterationSpec,
-    DoResult,
-    QuasiQuotation,
-    Recipient,
-    Init,
-    Step,
-    MacroUse,
-    MacroBlock,
-    Error
-}
+use crate::lexer::{Lexer, Token, TokenKind};
+use crate::tree::{Tree, TreeKind, FormalsTy, ListTy, DefineTy};
 
 #[derive(PartialEq, Eq)]
 enum BeginTerminalSite {
@@ -88,109 +9,16 @@ enum BeginTerminalSite {
     AtDefinition
 }
 
-pub struct Tree {
-    kind: TreeKind,
-    start: usize,
-    end: usize,
-    children: Option<Vec<Tree>>
-}
-
-impl Tree {
-    fn open(kind: TreeKind, start: usize) -> Tree {
-        Tree {
-            kind,
-            start,
-            end: start,
-            children: Some(Vec::new())
-        }
-    }
-
-    fn leaf(kind: TreeKind, token_at_leaf: &Token) -> Tree {
-        Tree {
-            kind,
-            start: token_at_leaf.start,
-            end: token_at_leaf.end,
-            children: None
-        }
-    }
-
-    fn close(&mut self, end: usize) {
-        self.end = end;
-    }
-
-    fn add_child(&mut self, child: Tree) {
-        // asserts for invalid parent kinds, 
-        // i.e these nodes don't expect children, 
-        // therefore a call on this function with any of them should result in failure
-        assert_ne!(self.kind, TreeKind::Boolean);
-        assert_ne!(self.kind, TreeKind::Token);
-        assert_ne!(self.kind, TreeKind::Character);
-        assert_ne!(self.kind, TreeKind::Number);
-        assert_ne!(self.kind, TreeKind::String);
-        assert_ne!(self.kind, TreeKind::Boolean);
-        assert_ne!(self.kind, TreeKind::Variable);
-        assert_ne!(self.kind, TreeKind::Keyword);
-        assert_ne!(self.kind, TreeKind::Error);
-
-        match self.children {
-            Some(ref mut vec) => {
-                if child.children_count() > 0 || matches!(child.kind, TreeKind::Token | TreeKind::Character | TreeKind::Number | TreeKind::String | TreeKind::Boolean | TreeKind::Variable | TreeKind::Keyword | TreeKind::Error) {
-                    vec.push(child);
-                }
-            },
-            None => return
-        }
-    }
-
-    fn children_count(&self) -> usize {
-        match self.children {
-            Some(ref vec) => vec.len(),
-            None => 0
-        }
-    }
-
-    fn print(&self, level: usize, lexer: &Lexer<'_>) {
-        let indent = "  ".repeat(level);
-        let children = &self.children;
-
-        match children {
-            Some(vec) => {
-                println!("{indent}{:?}", self.kind);
-
-                for child in vec{
-                    child.print(level + 1, lexer);
-                }
-            },
-            None => {
-                let literal = &lexer.code[self.start..self.end];
-                
-                if matches!(self.kind, TreeKind::Keyword | TreeKind::Variable | TreeKind::Boolean | TreeKind::Number | TreeKind::Character | TreeKind::String) {
-                    println!("{indent}{:?}", self.kind);
-                    println!("  {indent}{:?}", literal);
-                    return
-                } else if matches!(self.kind, TreeKind::Error) {
-                    println!("{indent}{:?}", self.kind);
-                    return
-                }
-                
-                let literal = &lexer.code[self.start..self.end];
-                println!("{indent}{:?}", literal);
-            }
-        }
-    }
-}
-
 pub struct Parser<'a> {
     lexer: Lexer<'a>,
     prev_token: Token,
     curr_token: Token,
     ahead_token: Token,
-    //after_curr: Token,
-    pub error_log: Vec<String>,
+    error_log: Vec<String>,
 }
 
-impl Parser<'_>{
-    pub fn new(lexer: Lexer<'_>) -> Parser {
+impl<'a> Parser<'a>{
+    pub fn new(lexer: Lexer<'a>) -> Parser<'a> {
         Parser {
             lexer: lexer,
             prev_token: Token{kind: TokenKind::Eof, start: 0, end: 1},
@@ -199,6 +27,18 @@ impl Parser<'_>{
             error_log: Vec::new()
         }
     }
+
+    pub fn has_errors(&self) -> bool {
+        return self.error_log.len() > 0
+    }
+
+    pub fn print_errors(&self) {
+        for error in &self.error_log {
+            println!("{}", error);
+        }
+    }
+
+    //pub fn generate_ir_from_parse_tree(&self, )
 
     // skip tokens until parser reaches non-whitespace delimiter token
     // TODO: Make whitespaces be possible synchronization points
@@ -210,7 +50,6 @@ impl Parser<'_>{
 
     fn add_error_msg_to_log(&mut self, expected: &str) {
         let as_str = &self.lexer.code[self.curr_token.start..self.curr_token.end];
-        //let source_tree: = &self.lexer.code[..self.curr_token.end];
         self.error_log.push(format!("ParseError: {}. Found '{}'({:?}) instead.", expected, as_str, self.curr_token.kind));
     }
 
@@ -296,21 +135,22 @@ impl Parser<'_>{
         | TokenKind::Quasiquote)
     }
 
-    fn list(&mut self) -> Tree {
-        let mut list = Tree::open(TreeKind::List, self.curr_token.start);
+    fn parse_list(&mut self) -> Tree {
+        let mut list = Tree::open(TreeKind::List(ListTy::Proper), self.curr_token.start);
 
         if self.at(TokenKind::Lparen) {
             list.add_child(Tree::leaf(TreeKind::Token, &self.curr_token));
             self.advance();
             while !self.at_any(&[TokenKind::Rparen, TokenKind::Eof, TokenKind::Dot]) {
-                list.add_child(self.datum());
+                list.add_child(self.parse_datum());
                 self.advance();
             }
 
             if list.children_count() > 2 && self.at(TokenKind::Dot) {
                 list.add_child(Tree::leaf(TreeKind::Token, &self.curr_token));
+                list.kind = TreeKind::List(ListTy::Improper);
                 self.advance();
-                list.add_child(self.datum());
+                list.add_child(self.parse_datum());
                 self.advance();
             }
             self.expect(&mut list, TokenKind::Rparen);
@@ -321,7 +161,7 @@ impl Parser<'_>{
             abbrev_prefix.close(self.curr_token.end);
             abbreviation.add_child(abbrev_prefix);
             self.advance();
-            abbreviation.add_child(self.datum());
+            abbreviation.add_child(self.parse_datum());
             abbreviation.close(self.curr_token.end);
             list.add_child(abbreviation);
         } else {
@@ -334,12 +174,12 @@ impl Parser<'_>{
         list
     }
 
-    fn vector(&mut self) -> Tree {
+    fn parse_vector(&mut self) -> Tree {
         let mut vector = Tree::open(TreeKind::Vector, self.curr_token.start);
         vector.add_child(Tree::leaf(TreeKind::Token, &self.curr_token));
         self.advance();
         while !self.at_any(&[TokenKind::Rparen, TokenKind::Eof]) {
-            vector.add_child(self.datum());
+            vector.add_child(self.parse_datum());
             self.advance();
         }
         self.expect(&mut vector, TokenKind::Rparen);
@@ -347,25 +187,27 @@ impl Parser<'_>{
         vector
     }
 
-    fn datum(&mut self) -> Tree {
+    fn parse_datum(&mut self) -> Tree {
         let mut datum = Tree::open(TreeKind::Datum, self.curr_token.start);
         if self.at_any(&[TokenKind::Lparen, TokenKind::Squote, TokenKind::Bquote, TokenKind::Comma, TokenKind::Seqcomma]){
             // List
             let mut compound_datum = Tree::open(TreeKind::CompoundDatum, self.curr_token.start);
-            compound_datum.add_child(self.list());
+            compound_datum.add_child(self.parse_list());
             compound_datum.close(self.curr_token.end);
             datum.add_child(compound_datum);
         } else if self.at(TokenKind::Sharplparen) {
             // Vectors
             let mut compound_datum = Tree::open(TreeKind::CompoundDatum, self.curr_token.start);
-            compound_datum.add_child(self.vector());
+            compound_datum.add_child(self.parse_vector());
             compound_datum.close(self.curr_token.end);
             datum.add_child(compound_datum);
         } else {
             let mut simple_datum = Tree::open(TreeKind::SimpleDatum, self.curr_token.start);
 
-            if self.at(TokenKind::True) || self.at(TokenKind::False) {
-                simple_datum.add_child(Tree::leaf(TreeKind::Boolean, &self.curr_token));
+            if self.at(TokenKind::True) {
+                simple_datum.add_child(Tree::leaf(TreeKind::BooleanT, &self.curr_token));
+            } else if self.at(TokenKind::False) {
+                simple_datum.add_child(Tree::leaf(TreeKind::BooleanF, &self.curr_token));
             } else if self.at(TokenKind::String) {
                 simple_datum.add_child(Tree::leaf(TreeKind::String, &self.curr_token));
             } else if self.at(TokenKind::Number) {
@@ -396,13 +238,13 @@ impl Parser<'_>{
         datum
     }
 
-    fn literal(&mut self) -> Tree {
+    fn parse_literal(&mut self) -> Tree {
         let mut literal = Tree::open(TreeKind::Literal, self.curr_token.start);
         if self.at(TokenKind::Squote) {
             let mut quotation = Tree::open(TreeKind::Quotation, self.curr_token.start);
             quotation.add_child(Tree::leaf(TreeKind::Token, &self.curr_token));
             self.advance();
-            quotation.add_child(self.datum());
+            quotation.add_child(self.parse_datum());
             quotation.close(self.curr_token.end);
             literal.add_child(quotation);
         } else if self.at(TokenKind::Lparen) && self.ahead(TokenKind::Quote) {
@@ -416,7 +258,7 @@ impl Parser<'_>{
             quotation.add_child(symbol);
 
             self.advance();
-            quotation.add_child(self.datum());
+            quotation.add_child(self.parse_datum());
             self.advance();
             self.expect(&mut quotation, TokenKind::Rparen);
             quotation.close(self.curr_token.end);
@@ -424,8 +266,10 @@ impl Parser<'_>{
         } else {
             let mut selfeval = Tree::open(TreeKind::SelfEvaluating, self.curr_token.start);
 
-            if self.at_any(&[TokenKind::False, TokenKind::True]) {
-                selfeval.add_child(Tree::leaf(TreeKind::Boolean, &self.curr_token));
+            if self.at(TokenKind::True) {
+                selfeval.add_child(Tree::leaf(TreeKind::BooleanT, &self.curr_token));
+            } else if self.at(TokenKind::False) {
+                selfeval.add_child(Tree::leaf(TreeKind::BooleanF, &self.curr_token));
             } else if self.at(TokenKind::Number) {
                 selfeval.add_child(Tree::leaf(TreeKind::Number, &self.curr_token));
             } else if self.at(TokenKind::Character) {
@@ -446,7 +290,7 @@ impl Parser<'_>{
         literal
     }
     
-    fn procedure_call(&mut self) -> Tree {
+    fn parse_procedure_call(&mut self) -> Tree {
         let mut proc_call = Tree::open(TreeKind::ProcedureCall, self.curr_token.start);
         // '('
         proc_call.add_child(Tree::leaf(TreeKind::Token, &self.curr_token));
@@ -454,7 +298,7 @@ impl Parser<'_>{
         self.advance();
         // operator
         let mut operator = Tree::open(TreeKind::Operator, self.curr_token.start);
-        operator.add_child(self.expression());
+        operator.add_child(self.parse_expression());
         operator.close(self.curr_token.end);
         proc_call.add_child(operator);
 
@@ -462,7 +306,7 @@ impl Parser<'_>{
         let mut operand = Tree::open(TreeKind::Operand, self.curr_token.start);
         self.advance();
         while !self.at_any(&[TokenKind::Rparen, TokenKind::Eof]) {
-            operand.add_child(self.expression());
+            operand.add_child(self.parse_expression());
             self.advance();
         }
         // curr is on eof or rparen
@@ -474,10 +318,10 @@ impl Parser<'_>{
         proc_call
     }
 
-    fn sequence(&mut self) -> Tree {
+    fn parse_sequence(&mut self) -> Tree {
         let mut sequence = Tree::open(TreeKind::Sequence, self.curr_token.start);
         let mut command = Tree::open(TreeKind::Command, self.curr_token.start);
-        command.add_child(self.expression());
+        command.add_child(self.parse_expression());
         self.advance();
         // while at possible expression start token
         while self.at_any(&[TokenKind::Squote, TokenKind::True, 
@@ -486,7 +330,7 @@ impl Parser<'_>{
                                 TokenKind::Variable, TokenKind::Lparen, 
                                 TokenKind::Bquote]) 
         {
-            command.add_child(self.expression());
+            command.add_child(self.parse_expression());
             self.advance();
         }
         command.close(self.prev_token.end);
@@ -495,23 +339,23 @@ impl Parser<'_>{
         sequence
     }
 
-    fn body(&mut self) -> Tree {
+    fn parse_body(&mut self) -> Tree {
         let mut body = Tree::open(TreeKind::Body, self.curr_token.start);
         
         while self.at(TokenKind::Lparen) && self.ahead_any(&[TokenKind::Define, TokenKind::Begin]) {
-            body.add_child(self.definition(BeginTerminalSite::AtDefinition));
+            body.add_child(self.parse_definition(BeginTerminalSite::AtDefinition));
             self.advance();
         }
 
-        body.add_child(self.sequence());
+        body.add_child(self.parse_sequence());
 
         body.close(self.curr_token.end);
         body
     }
     
-    fn definition(&mut self, site: BeginTerminalSite) -> Tree {
+    fn parse_definition(&mut self, site: BeginTerminalSite) -> Tree {
         let mut definition = match site {
-            BeginTerminalSite::AtDefinition => Tree::open(TreeKind::Definition, self.curr_token.start),
+            BeginTerminalSite::AtDefinition => Tree::open(TreeKind::Definition(DefineTy::Type1), self.curr_token.start),
             BeginTerminalSite::AtCommandOrDefinition => Tree::open(TreeKind::CommandOrDefinition, self.curr_token.start)
         };
 
@@ -533,22 +377,25 @@ impl Parser<'_>{
                     self.advance();
                 }
                 if self.at(TokenKind::Dot) {
+                    definition.kind = TreeKind::Definition(DefineTy::Type3);
+                    def_formals.add_child(Tree::leaf(TreeKind::Token, &self.curr_token));
                     self.advance();
                     self.expect(&mut def_formals, TokenKind::Variable);
                     def_formals.close(self.curr_token.end);
                     self.advance();
                 } else {
+                    definition.kind = TreeKind::Definition(DefineTy::Type2);
                     def_formals.close(self.prev_token.end);
                     definition.add_child(def_formals);
                 }
                 self.expect(&mut definition, TokenKind::Rparen);
                 self.advance();
                 // body
-                definition.add_child(self.body());
+                definition.add_child(self.parse_body());
             } else {
                 self.expect(&mut definition, TokenKind::Variable);
                 self.advance();
-                definition.add_child(self.expression());
+                definition.add_child(self.parse_expression());
                 self.advance();
             }
         } else if self.at(TokenKind::Begin) {
@@ -557,12 +404,12 @@ impl Parser<'_>{
             
             if site == BeginTerminalSite::AtCommandOrDefinition {
                 while !self.at_any(&[TokenKind::Rparen, TokenKind::Eof]) {
-                    self.command_or_definition();
+                    self.parse_command_or_definition();
                     self.advance();
                 }
             } else {
                 while self.at(TokenKind::Lparen) {
-                    definition.add_child(self.definition(BeginTerminalSite::AtDefinition));
+                    definition.add_child(self.parse_definition(BeginTerminalSite::AtDefinition));
                     self.advance();
                 }
             }
@@ -578,8 +425,8 @@ impl Parser<'_>{
         definition
     }
 
-    fn lambda(&mut self) -> Tree {
-        let mut lam = Tree::open(TreeKind::LambdaExpr, self.curr_token.start);
+    fn parse_lambda(&mut self) -> Tree {
+        let mut lam = Tree::open(TreeKind::LambdaExpr(FormalsTy::Type1), self.curr_token.start);
         // (
         lam.add_child(Tree::leaf(TreeKind::Token, &self.curr_token));
         
@@ -600,12 +447,15 @@ impl Parser<'_>{
             }
 
             if formals.children_count() > 2 && self.at(TokenKind::Dot) {
+                formals.add_child(Tree::leaf(TreeKind::Token, &self.curr_token));
                 self.advance();
+                lam.kind = TreeKind::LambdaExpr(FormalsTy::Type3);
                 self.expect(&mut formals, TokenKind::Variable);
             }
             
             self.expect(&mut formals, TokenKind::Rparen);
         } else {
+            lam.kind = TreeKind::LambdaExpr(FormalsTy::Type2);
             self.expect(&mut formals, TokenKind::Variable);
         }
         formals.close(self.curr_token.end);
@@ -613,7 +463,7 @@ impl Parser<'_>{
         
         // body
         self.advance();
-        lam.add_child(self.body());
+        lam.add_child(self.parse_body());
 
         self.expect(&mut lam, TokenKind::Rparen);
 
@@ -621,7 +471,7 @@ impl Parser<'_>{
         lam
     }
 
-    fn conditional(&mut self) -> Tree {
+    fn parse_conditional(&mut self) -> Tree {
         let mut conditional = Tree::open(TreeKind::Conditional, self.curr_token.start);
         // (
         conditional.add_child(Tree::leaf(TreeKind::Token, &self.curr_token));
@@ -632,13 +482,13 @@ impl Parser<'_>{
 
         self.advance();
         let mut test = Tree::open(TreeKind::Test, self.curr_token.start);
-        test.add_child(self.expression());
+        test.add_child(self.parse_expression());
         test.close(self.curr_token.end);
         conditional.add_child(test);
 
         self.advance();
         let mut consequent = Tree::open(TreeKind::Consequent, self.curr_token.start);
-        consequent.add_child(self.expression());
+        consequent.add_child(self.parse_expression());
         consequent.close(self.curr_token.end);
         conditional.add_child(consequent);
 
@@ -651,7 +501,7 @@ impl Parser<'_>{
         }
         
         let mut alternate = Tree::open(TreeKind::Alternate, self.curr_token.start);
-        alternate.add_child(self.expression());
+        alternate.add_child(self.parse_expression());
         alternate.close(self.curr_token.end);
         conditional.add_child(alternate);
 
@@ -662,7 +512,7 @@ impl Parser<'_>{
         conditional
     }
 
-    fn assignment(&mut self) -> Tree {
+    fn parse_assignment(&mut self) -> Tree {
         let mut assignment = Tree::open(TreeKind::Assignment, self.curr_token.start);
         // (
         assignment.add_child(Tree::leaf(TreeKind::Token, &self.curr_token));
@@ -675,7 +525,7 @@ impl Parser<'_>{
         self.expect(&mut assignment, TokenKind::Variable);
 
         self.advance();
-        assignment.add_child(self.expression());
+        assignment.add_child(self.parse_expression());
 
         self.advance();
         self.expect(&mut assignment, TokenKind::Rparen);
@@ -684,7 +534,7 @@ impl Parser<'_>{
         assignment
     }
 
-    fn cond_clause(&mut self) -> Tree {
+    fn parse_cond_clause(&mut self) -> Tree {
         let mut cond_clause = Tree::open(TreeKind::CondClause, self.curr_token.start);
 
         // (
@@ -692,7 +542,7 @@ impl Parser<'_>{
 
         self.advance();
         let mut test = Tree::open(TreeKind::Test, self.curr_token.start);
-        test.add_child(self.expression());
+        test.add_child(self.parse_expression());
         test.close(self.curr_token.end);
         cond_clause.add_child(test);
 
@@ -705,14 +555,14 @@ impl Parser<'_>{
 
             self.advance();
             let mut recipient = Tree::open(TreeKind::Recipient, self.curr_token.start);
-            recipient.add_child(self.expression());
+            recipient.add_child(self.parse_expression());
             recipient.close(self.curr_token.end);
             cond_clause.add_child(recipient);
 
             self.advance();
             self.expect(&mut cond_clause, TokenKind::Rparen);
         } else {
-            cond_clause.add_child(self.sequence());
+            cond_clause.add_child(self.parse_sequence());
             self.expect(&mut cond_clause, TokenKind::Rparen);
         }
 
@@ -720,7 +570,7 @@ impl Parser<'_>{
         cond_clause
     }
     
-    fn case_clause(&mut self) -> Tree {
+    fn parse_case_clause(&mut self) -> Tree {
         let mut case_clause = Tree::open(TreeKind::CaseClause, self.curr_token.start);
         self.expect(&mut case_clause, TokenKind::Lparen);
         self.advance();
@@ -729,20 +579,20 @@ impl Parser<'_>{
         self.advance();
 
         while !self.at_any(&[TokenKind::Rparen, TokenKind::Eof]) {
-            case_clause.add_child(self.datum());
+            case_clause.add_child(self.parse_datum());
             self.advance();
         }
 
         self.expect(&mut case_clause, TokenKind::Rparen);
         self.advance();
-        case_clause.add_child(self.sequence());
+        case_clause.add_child(self.parse_sequence());
         self.expect(&mut case_clause, TokenKind::Rparen);
 
         case_clause.close(self.curr_token.end);
         case_clause
     }
 
-    fn binding_spec(&mut self) -> Tree {
+    fn parse_binding_spec(&mut self) -> Tree {
         let mut binding_spec = Tree::open(TreeKind::BindingSpec, self.curr_token.start);
 
         self.expect(&mut binding_spec, TokenKind::Lparen);
@@ -751,7 +601,7 @@ impl Parser<'_>{
         self.expect(&mut binding_spec, TokenKind::Variable);
 
         self.advance();
-        binding_spec.add_child(self.expression());
+        binding_spec.add_child(self.parse_expression());
 
         self.advance();
         self.expect(&mut binding_spec, TokenKind::Rparen);
@@ -760,7 +610,7 @@ impl Parser<'_>{
         binding_spec
     }
 
-    fn iteration_spec(&mut self) -> Tree {
+    fn parse_iteration_spec(&mut self) -> Tree {
         let mut iteration_spec = Tree::open(TreeKind::IterationSpec, self.curr_token.start);
 
         self.expect(&mut iteration_spec, TokenKind::Lparen);
@@ -770,7 +620,7 @@ impl Parser<'_>{
 
         self.advance();
         let mut init = Tree::open(TreeKind::Init, self.curr_token.start);
-        init.add_child(self.expression());
+        init.add_child(self.parse_expression());
         init.close(self.curr_token.end);
         iteration_spec.add_child(init);
 
@@ -782,7 +632,7 @@ impl Parser<'_>{
         }
 
         let mut step = Tree::open(TreeKind::Step, self.curr_token.start);
-        step.add_child(self.expression());
+        step.add_child(self.parse_expression());
         step.close(self.curr_token.end);
         iteration_spec.add_child(step);
 
@@ -793,7 +643,7 @@ impl Parser<'_>{
         iteration_spec
     }
 
-    fn derived_expression(&mut self) -> Tree {
+    fn parse_derived_expression(&mut self) -> Tree {
         // every derived expression but quasi-quotations get parsed here
         let mut derived_expr = Tree::open(TreeKind::DerivedExpr, self.curr_token.start);
         derived_expr.add_child(Tree::leaf(TreeKind::Token, &self.curr_token));
@@ -809,7 +659,7 @@ impl Parser<'_>{
                                                                             TokenKind::Variable, TokenKind::Lparen, 
                                                                             TokenKind::Bquote])
             {
-                derived_expr.add_child(self.cond_clause());
+                derived_expr.add_child(self.parse_cond_clause());
                 self.advance();
             }
 
@@ -825,18 +675,18 @@ impl Parser<'_>{
             self.expect(&mut derived_expr, TokenKind::Else);
             
             self.advance();
-            derived_expr.add_child(self.sequence());
+            derived_expr.add_child(self.parse_sequence());
             self.expect(&mut derived_expr, TokenKind::Rparen);
             self.advance();
         } else if self.at(TokenKind::Case) {
             derived_expr.add_child(Tree::leaf(TreeKind::Token, &self.curr_token));
 
             self.advance();
-            derived_expr.add_child(self.expression());
+            derived_expr.add_child(self.parse_expression());
 
             self.advance();
             while self.at(TokenKind::Lparen) && self.ahead(TokenKind::Lparen) {
-                derived_expr.add_child(self.case_clause());
+                derived_expr.add_child(self.parse_case_clause());
                 self.advance();
             }
 
@@ -852,7 +702,7 @@ impl Parser<'_>{
             self.expect(&mut derived_expr, TokenKind::Else);
 
             self.advance();
-            derived_expr.add_child(self.sequence());
+            derived_expr.add_child(self.parse_sequence());
             self.expect(&mut derived_expr, TokenKind::Rparen);
             self.advance();
         } else if self.at(TokenKind::And) || self.at(TokenKind::Or) {
@@ -868,7 +718,7 @@ impl Parser<'_>{
                                                                             TokenKind::Variable, TokenKind::Lparen, 
                                                                             TokenKind::Bquote])
             {
-                test.add_child(self.expression());
+                test.add_child(self.parse_expression());
                 self.advance();
             }
 
@@ -887,13 +737,13 @@ impl Parser<'_>{
             
             self.advance();
             while self.at(TokenKind::Lparen) && self.ahead(TokenKind::Variable) {
-                derived_expr.add_child(self.binding_spec());
+                derived_expr.add_child(self.parse_binding_spec());
                 self.advance();
             }
 
             self.expect(&mut derived_expr, TokenKind::Rparen);
             self.advance();
-            derived_expr.add_child(self.body());
+            derived_expr.add_child(self.parse_body());
         } else if self.at_any(&[TokenKind::LetStar, TokenKind::LetRec]) {
             derived_expr.add_child(Tree::leaf(TreeKind::Token, &self.curr_token));
 
@@ -902,18 +752,18 @@ impl Parser<'_>{
 
             self.advance();
             while self.at(TokenKind::Lparen) && self.ahead(TokenKind::Variable) {
-                derived_expr.add_child(self.binding_spec());
+                derived_expr.add_child(self.parse_binding_spec());
                 self.advance();
             }
 
             self.expect(&mut derived_expr, TokenKind::Rparen);
             self.advance();
-            derived_expr.add_child(self.body());
+            derived_expr.add_child(self.parse_body());
         } else if self.at(TokenKind::Begin) {
             derived_expr.add_child(Tree::leaf(TreeKind::Token, &self.curr_token));
 
             self.advance();
-            derived_expr.add_child(self.sequence());
+            derived_expr.add_child(self.parse_sequence());
         } else if self.at(TokenKind::Do) {
             derived_expr.add_child(Tree::leaf(TreeKind::Token, &self.curr_token));
 
@@ -922,7 +772,7 @@ impl Parser<'_>{
 
             self.advance();
             while self.at(TokenKind::Lparen) && self.ahead(TokenKind::Variable) {
-                derived_expr.add_child(self.iteration_spec());
+                derived_expr.add_child(self.parse_iteration_spec());
                 self.advance();
             }
 
@@ -933,7 +783,7 @@ impl Parser<'_>{
 
             self.advance();
             let mut test = Tree::open(TreeKind::Test, self.curr_token.start);
-            test.add_child(self.expression());
+            test.add_child(self.parse_expression());
             test.close(self.curr_token.end);
             derived_expr.add_child(test);
 
@@ -941,7 +791,7 @@ impl Parser<'_>{
             if !self.at(TokenKind::Rparen) {
                 let mut do_result = Tree::open(TreeKind::DoResult, self.curr_token.start);
 
-                do_result.add_child(self.sequence());
+                do_result.add_child(self.parse_sequence());
 
                 do_result.close(self.curr_token.end);
                 derived_expr.add_child(do_result);
@@ -956,7 +806,7 @@ impl Parser<'_>{
                                                                             TokenKind::Variable, TokenKind::Lparen, 
                                                                             TokenKind::Bquote])
             {
-                command.add_child(self.expression());
+                command.add_child(self.parse_expression());
                 self.advance();
             } 
             command.close(self.curr_token.end);
@@ -964,7 +814,7 @@ impl Parser<'_>{
         } else if self.at(TokenKind::Delay) {
             derived_expr.add_child(Tree::leaf(TreeKind::Token, &self.curr_token));
             self.advance();
-            derived_expr.add_child(self.expression());
+            derived_expr.add_child(self.parse_expression());
             self.advance();
         }
 
@@ -973,30 +823,30 @@ impl Parser<'_>{
         derived_expr
     }
     
-    fn expression(&mut self) -> Tree {
+    fn parse_expression(&mut self) -> Tree {
         let mut expression = Tree::open(TreeKind::Expression, self.curr_token.start);
         if self.at(TokenKind::Variable) {
             expression.add_child(Tree::leaf(TreeKind::Variable, &self.curr_token));
         } else if self.at_any(&[TokenKind::Squote, TokenKind::True, TokenKind::False, TokenKind::Number, TokenKind::Character, TokenKind::String]) {
-            expression.add_child(self.literal());
+            expression.add_child(self.parse_literal());
         } else if self.at(TokenKind::Lparen) {
             if self.ahead(TokenKind::Quote) {
-                expression.add_child(self.literal());
+                expression.add_child(self.parse_literal());
             } else if self.ahead(TokenKind::Lambda) {
                 // lambda expression
-                expression.add_child(self.lambda());
+                expression.add_child(self.parse_lambda());
             } else if self.ahead(TokenKind::If) {
                 // conditional expression
-                expression.add_child(self.conditional());
+                expression.add_child(self.parse_conditional());
             } else if self.ahead(TokenKind::SetExPt) {
                 // assignment expression
-                expression.add_child(self.assignment());
+                expression.add_child(self.parse_assignment());
             } else if self.ahead_any(&[TokenKind::Cond, TokenKind::Case, TokenKind::And, TokenKind::Or, TokenKind::Let, TokenKind::LetStar, TokenKind::LetRec, TokenKind::Begin, TokenKind::Do, TokenKind::Delay, TokenKind::Quasiquote]) {
                 // derived expression
-                expression.add_child(self.derived_expression());
+                expression.add_child(self.parse_derived_expression());
             } else {
                 // procedure call
-                expression.add_child(self.procedure_call());
+                expression.add_child(self.parse_procedure_call());
             }
         } else if self.at(TokenKind::Bquote) {
             // quasiquotation
@@ -1010,25 +860,36 @@ impl Parser<'_>{
         expression
     }
 
-    fn command_or_definition(&mut self) -> Tree {
+    fn parse_command_or_definition(&mut self) -> Tree {
         let mut cod = Tree::open(TreeKind::CommandOrDefinition, self.curr_token.start);
 
         if self.at(TokenKind::Lparen) {
             if self.ahead(TokenKind::Define) {
-                cod.add_child(self.definition(BeginTerminalSite::AtDefinition));
+                cod.add_child(self.parse_definition(BeginTerminalSite::AtDefinition));
             } else if self.ahead(TokenKind::Define) {
-                cod.add_child(self.definition(BeginTerminalSite::AtCommandOrDefinition));
+                cod.add_child(self.parse_definition(BeginTerminalSite::AtCommandOrDefinition));
             } else if self.ahead(TokenKind::DefineSyntax){
                 // define-syntax
+            } else if self.ahead(TokenKind::Begin) {
+                cod.add_child(Tree::leaf(TreeKind::Token, &self.curr_token));
+                self.advance();
+                cod.add_child(Tree::leaf(TreeKind::Keyword, &self.curr_token));
+                self.advance();
+                if self.at(TokenKind::Lparen) {
+                    cod.add_child(Tree::leaf(TreeKind::Error, &self.curr_token));
+                    self.add_error_msg_to_log("Expected a command or definition following 'begin' keyword");
+                    self.synchronize_from_parse_error();
+                }
+                cod.add_child(self.parse_command_or_definition());
             } else {
                 let mut command = Tree::open(TreeKind::Command, self.curr_token.start);
-                command.add_child(self.expression());
+                command.add_child(self.parse_expression());
                 command.close(self.curr_token.end);
                 cod.add_child(command);
             }
         } else {
             let mut command = Tree::open(TreeKind::Command, self.curr_token.start);
-            command.add_child(self.expression());
+            command.add_child(self.parse_expression());
             command.close(self.curr_token.end);
             cod.add_child(command);
         }
@@ -1045,11 +906,11 @@ impl Parser<'_>{
             if self.at(TokenKind::Eof) {
                 break;
             }
-            program.add_child(self.command_or_definition());
+            program.add_child(self.parse_command_or_definition());
             self.advance();
         }
         program.close(self.curr_token.end);
-        program.print(0, &self.lexer);
+        program.print(0, self.lexer.code);
         program
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -153,10 +153,10 @@ mod lexer_tests {
             let mut lexer = Lexer::new(code, code.chars());
             let returned_token = lexer.next_token().unwrap();
             assert_eq!(expected_token, returned_token.kind);
-            if expected_token != TokenKind::Character {
-                assert_eq!(*code, lexer.code[returned_token.start..returned_token.end]);
-            } else {
+            if expected_token == TokenKind::Character {
                 assert_eq!(code[returned_token.start..returned_token.end], lexer.code[returned_token.start..returned_token.end]);
+            } else {
+                assert_eq!(*code, lexer.code[returned_token.start..returned_token.end]);
             }
         }
     }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,0 +1,443 @@
+use std::collections::VecDeque;
+use std::ops::Deref;
+
+use crate::ir::{IrArena, PrimIr, PrimIrKind, IrID};
+use crate::lexer::Token;
+
+#[derive(PartialEq, Eq, Debug)]
+pub enum FormalsTy {
+    Type1,
+    Type2,
+    Type3
+}
+
+#[derive(PartialEq, Eq, Debug)]
+pub enum ListTy {
+    Proper,
+    Improper
+}
+
+#[derive(PartialEq, Eq, Debug)]
+pub enum DefineTy {
+    Type1,
+    Type2,
+    Type3
+}
+
+#[derive(PartialEq, Debug)]
+pub enum TreeKind {
+    Program,
+    CommandOrDefinition,
+    Token,
+    Expression,
+    BooleanT,
+    BooleanF,
+    Number,
+    Variable,
+    Character,
+    String,
+    Literal,
+    Quotation,
+    SelfEvaluating,
+    Datum,
+    SimpleDatum,
+    CompoundDatum,
+    List(ListTy),
+    Vector,
+    Abbreviation,
+    AbbrevPrefix,
+    Symbol,
+    Keyword,
+    ProcedureCall,
+    Operator,
+    Operand,
+    LambdaExpr(FormalsTy),
+    Formals,
+    Body,
+    Definition(DefineTy),
+    DefFormals,
+    Sequence,
+    Command,
+    Conditional,
+    Test,
+    Consequent,
+    Alternate,
+    Assignment,
+    DerivedExpr,
+    CondClause,
+    CaseClause,
+    BindingSpec,
+    IterationSpec,
+    DoResult,
+    QuasiQuotation,
+    Recipient,
+    Init,
+    Step,
+    MacroUse,
+    MacroBlock,
+    Error
+}
+
+pub struct Tree {
+    pub kind: TreeKind,
+    pub start: usize,
+    pub end: usize,
+    pub children: Option<Vec<Tree>>
+}
+
+impl Tree {
+    pub fn open(kind: TreeKind, start: usize) -> Tree {
+        Tree {
+            kind,
+            start,
+            end: start,
+            children: Some(Vec::new())
+        }
+    }
+
+    pub fn leaf(kind: TreeKind, token_at_leaf: &Token) -> Tree {
+        Tree {
+            kind,
+            start: token_at_leaf.start,
+            end: token_at_leaf.end,
+            children: None
+        }
+    }
+
+    pub fn close(&mut self, end: usize) {
+        self.end = end;
+    }
+
+    pub fn add_child(&mut self, child: Tree) {
+        // asserts for invalid parent kinds, 
+        // i.e these nodes don't expect children, 
+        // therefore a call on this function with any of them should result in failure
+        assert!(!matches!(self.kind, TreeKind::BooleanT | TreeKind::BooleanF | TreeKind::Character | TreeKind::Number | TreeKind::String | TreeKind::Variable | TreeKind::Keyword | TreeKind::Error), "Invalid attempt to add child to barren node");
+
+        match self.children {
+            Some(ref mut vec) => {
+                if child.children_count() > 0 || matches!(child.kind, TreeKind::Token | TreeKind::Character | TreeKind::Number | TreeKind::String | TreeKind::BooleanT | TreeKind::BooleanF | TreeKind::Variable | TreeKind::Keyword | TreeKind::Error) {
+                    vec.push(child);
+                }
+            },
+            None => return
+        }
+    }
+
+    pub fn children_count(&self) -> usize {
+        match self.children {
+            Some(ref vec) => vec.len(),
+            None => 0
+        }
+    }
+
+    pub fn print(&self, level: usize, code: &str) {
+        let indent = "  ".repeat(level);
+        let children = &self.children;
+
+        match children {
+            Some(vec) => {
+                println!("{indent}{:?}", self.kind);
+
+                for child in vec{
+                    child.print(level + 1, code);
+                }
+            },
+            None => {
+                let literal = &code[self.start..self.end];
+                
+                if matches!(self.kind, TreeKind::Keyword | TreeKind::Variable | TreeKind::BooleanT | TreeKind::BooleanF | TreeKind::Number | TreeKind::Character | TreeKind::String) {
+                    println!("{indent}{:?}", self.kind);
+                    println!("  {indent}{:?}", literal);
+                    return
+                } else if matches!(self.kind, TreeKind::Error) {
+                    println!("{indent}{:?}", self.kind);
+                    return
+                }
+                
+                let literal = &code[self.start..self.end];
+                println!("{indent}{:?}", literal);
+            }
+        }
+    }
+
+    fn node_is_keyword(
+        node: &Tree,
+        code_ctx: &str,
+        keyword: &str
+    ) -> bool {
+        if node.kind == TreeKind::Keyword && code_ctx[node.start..node.end] == *keyword {
+            return true
+        }
+
+        false
+    }
+
+    fn list_to_prim_ir(
+        mut children: VecDeque<&Tree>,
+        list_type: ListTy,
+        arena: &mut IrArena<PrimIr>,
+        code_ctx: &str
+    ) -> Option<IrID> {
+        match children.pop_front() {
+            Some(element) => {
+                if children.len() == 0 && list_type == ListTy::Improper {
+                    return Some(element.to_prim_ir(arena, code_ctx));
+                }
+                
+                let car = element.to_prim_ir(arena, code_ctx);
+                let cdr = Tree::list_to_prim_ir(children, list_type, arena, code_ctx);
+                let kind = PrimIrKind::Pair{car, cdr};
+                let id = arena.add(PrimIr { kind }, (element.start, element.end));
+                return Some(id)
+            },
+            None => {
+                return None
+            }
+        };
+    }
+
+    fn lambda_to_prim_ir(
+        &self,
+        formals_node: &Tree,
+        body_node: &Tree,
+        ty: FormalsTy,
+        arena: &mut IrArena<PrimIr>,
+        code_ctx: &str
+    ) -> IrID {
+        let children: VecDeque<&Tree> = formals_node.children.as_ref()
+                                                .unwrap().iter()
+                                                .filter(|n| n.kind != TreeKind::Token)
+                                                .collect();
+        let mut formals: Vec<IrID> = Vec::new();
+        for child in children {
+            formals.push(child.to_prim_ir(arena, code_ctx));
+        }
+
+        let children: VecDeque<&Tree> = body_node.children.as_ref()
+                                                .unwrap().iter()
+                                                .filter(|n| n.kind != TreeKind::Token)
+                                                .collect();
+        let mut body: Vec<IrID> = Vec::new();
+        for child in children {
+            body.push(child.to_prim_ir(arena, code_ctx));
+        }
+        let kind = PrimIrKind::Lambda{ty, formals, body};
+        let id = arena.add(PrimIr { kind }, (self.start, self.end));
+        id
+    }
+
+    fn cond_to_prim_ir(&mut self, mut children: VecDeque<&Tree>, arena: &mut IrArena<PrimIr>, code_ctx: &str) -> IrID {
+        let mut desugared: Vec<IrID> = Vec::new();
+        for child in children {
+            desugared.push(child.to_prim_ir(arena, code_ctx));
+        }
+        if Tree::node_is_keyword(children[0], code_ctx, "else") {
+            children.pop_front();
+            let mut expressions: Vec<IrID> = Vec::new();
+            for child in children {
+                expressions.push(child.to_prim_ir(arena, code_ctx));
+            }
+            let kind = PrimIrKind::Exprs(expressions);
+            let id = arena.add(PrimIr { kind }, (self.start, self.end));
+            return id;
+        } else 
+        0
+    }
+
+    pub fn to_prim_ir(&self, arena: &mut IrArena<PrimIr>, code_ctx: &str) -> IrID {
+        let children: Option<VecDeque<&Tree>> = if self.children.is_some() {
+            Some(self.children.unwrap().iter().filter(|n| n.kind != TreeKind::Token).collect())
+        } else {
+            None
+        };
+
+        match self.kind {
+            TreeKind::Program => {
+                let children = children.unwrap();
+                let mut expressions: Vec<IrID> = Vec::new();
+                for child in children {
+                    expressions.push(child.to_prim_ir(arena, code_ctx));
+                }
+                let kind = PrimIrKind::Exprs(expressions);
+                let id = arena.add(PrimIr { kind }, (self.start, self.end));
+                id
+            },
+            TreeKind::CommandOrDefinition => {
+                let mut children = children.unwrap();
+                if children.len() == 1 {
+                    return children[0].to_prim_ir(arena, code_ctx);
+                }
+                // pop begin keyword node
+                children.pop_front();
+                let mut expressions: Vec<IrID> = Vec::new();
+                for child in children {
+                    expressions.push(child.to_prim_ir(arena, code_ctx));
+                }
+                let kind = PrimIrKind::Exprs(expressions);
+                let id = arena.add(PrimIr { kind }, (self.start, self.end));
+                id
+            },
+            TreeKind::Expression | TreeKind::Literal | TreeKind::SelfEvaluating | TreeKind::Datum | TreeKind::SimpleDatum | TreeKind::CompoundDatum | TreeKind::Operator | TreeKind::Operand => {
+                // number of children is always 1
+                let children = children.unwrap();
+                return children[0].to_prim_ir(arena, code_ctx);
+            },
+            TreeKind::BooleanT => {
+                let kind = PrimIrKind::Boolean(true);
+                let id = arena.add(PrimIr { kind }, (self.start, self.end));
+                id
+            },
+            TreeKind::BooleanF => {
+                let kind = PrimIrKind::Boolean(false);
+                let id = arena.add(PrimIr { kind }, (self.start, self.end));
+                id
+            },
+            TreeKind::Number => {
+                // TODO this
+                0
+            },
+            TreeKind::Variable | TreeKind::Keyword => {
+                let kind = PrimIrKind::Symbol(code_ctx[self.start..self.end].to_string());
+                let id = arena.add(PrimIr { kind }, (self.start, self.end));
+                id
+            },
+            TreeKind::Character => {
+                let kind = PrimIrKind::Char(code_ctx[self.start..self.end].to_string());
+                let id = arena.add(PrimIr { kind }, (self.start, self.end));
+                id
+            },
+            TreeKind::String => {
+                let kind = PrimIrKind::String(code_ctx[self.start..self.end].to_string());
+                let id = arena.add(PrimIr { kind }, (self.start, self.end));
+                id
+            },
+            TreeKind::Quotation => {
+                let children = children.unwrap();
+                if children.len() == 1 {
+                    return children[0].to_prim_ir(arena, code_ctx);
+                }
+
+                return children[1].to_prim_ir(arena, code_ctx);
+            },
+            TreeKind::List(list_type) => {
+                let children = children.unwrap();
+                 
+                match Tree::list_to_prim_ir(children, list_type, arena, code_ctx) {
+                    Some(ir_id) => return ir_id,
+                    None => {
+                        let id = arena.add(PrimIr { kind: PrimIrKind::Error}, (self.start, self.end));
+                        id
+                    }
+                }
+            },
+            TreeKind::Vector => {
+                let children = children.unwrap();
+                let mut datums: Vec<IrID> = Vec::new();
+                for child in children {
+                    datums.push(child.to_prim_ir(arena, code_ctx));
+                }
+                let kind = PrimIrKind::Vector(datums);
+                let id = arena.add(PrimIr { kind }, (self.start, self.end));
+                id
+            },
+            TreeKind::Abbreviation => {
+                let children = children.unwrap();
+                // index 0 is abbrev prefix
+                return children[1].to_prim_ir(arena, code_ctx)
+            },
+            TreeKind::Symbol => {
+                let children = children.unwrap();
+                return children[0].to_prim_ir(arena, code_ctx);
+            },
+            TreeKind::ProcedureCall => {
+                let mut children = children.unwrap();
+                let operator = children[0].to_prim_ir(arena, code_ctx);
+                let mut operands: Vec<IrID> = Vec::new();
+                for child in children {
+                    operands.push(child.to_prim_ir(arena, code_ctx));
+                }
+                let kind = PrimIrKind::Call{operator, operands};
+                let id = arena.add(PrimIr {kind}, (self.start, self.end));
+                id
+            },
+            TreeKind::LambdaExpr(formals_type) => {
+                let children = children.unwrap();
+                let ty = formals_type;
+
+                return self.lambda_to_prim_ir(children[1], children[2], ty, arena, code_ctx);
+            },
+            TreeKind::Definition(define_type) => {
+                let mut children = children.unwrap();
+                if Tree::node_is_keyword(children[0], code_ctx, "begin") {
+                    children.pop_front();
+                    let mut expressions: Vec<IrID> = Vec::new();
+                    for child in children {
+                        expressions.push(child.to_prim_ir(arena, code_ctx));
+                    }
+                    let kind = PrimIrKind::Exprs(expressions);
+                    let id = arena.add(PrimIr { kind }, (self.start, self.end));
+                    return id
+                }
+                
+                let name = children[1].to_prim_ir(arena, code_ctx);
+                let mut value: IrID = 0;
+                match define_type {
+                    DefineTy::Type1 => {
+                        value = children[2].to_prim_ir(arena, code_ctx);
+                    },
+                    DefineTy::Type2 => {
+                        value = self.lambda_to_prim_ir(children[2], children[3], FormalsTy::Type1, arena, code_ctx);
+                    },
+                    DefineTy::Type3 => {
+                        value = self.lambda_to_prim_ir(children[2], children[3], FormalsTy::Type3, arena, code_ctx);
+                    }
+                }
+                let kind = PrimIrKind::Define {name, value};
+                let id = arena.add(PrimIr { kind }, (self.start, self.end));
+                id
+            },
+            TreeKind::Conditional => {
+                let children = children.unwrap();
+                let test = children[1].to_prim_ir(arena, code_ctx);
+                let consequent = children[2].to_prim_ir(arena, code_ctx);
+                let mut alternate: Option<IrID> = None;
+                if children.len() > 3 {
+                    alternate = Some(children[3].to_prim_ir(arena, code_ctx));
+                }
+
+                let kind = PrimIrKind::Conditional {test, consequent, alternate};
+                let id = arena.add(PrimIr { kind }, (self.start, self.end));
+                id
+            },
+            TreeKind::Assignment => {
+                let children = children.unwrap();
+                let variable = children[1].to_prim_ir(arena, code_ctx);
+                let expression = children[2].to_prim_ir(arena, code_ctx);
+                let kind = PrimIrKind::Set{variable, expression};
+                let id = arena.add(PrimIr {kind}, (self.start, self.end));
+                id
+            },
+            TreeKind::DerivedExpr => {
+                let mut children = children.unwrap();
+                if Tree::node_is_keyword(children[0], code_ctx, "cond") {
+                    children.pop_front();
+                    let mut desugared: Vec<IrID> = Vec::new();
+                    for child in children {
+                        if Tree::node_is_keyword(child, code_ctx, keyword)
+                        desugared.push(child.to_prim_ir(arena, code_ctx));
+                    }
+                } else if Tree::node_is_keyword(children[0], code_ctx, "case") {
+                    
+                } else if Tree::node_is_keyword(children[0], code_ctx, "and") {
+                    
+                } else if Tree::node_is_keyword(children[0], code_ctx, "or") {
+
+                } else if Tree::node_is_keyword(node, code_ctx, keyword)
+            },
+            TreeKind::CondClause => {
+                
+            }
+        }
+    }
+}


### PR DESCRIPTION
Define a primitive IR that all Scheme constructs would be reduced to as the final stage of parsing. This IR is what will be evaluated in the interpreter